### PR TITLE
FBX Import/Export Interfaces

### DIFF
--- a/AssetManagment/AssetHandling/MeshImportExporter.cs
+++ b/AssetManagment/AssetHandling/MeshImportExporter.cs
@@ -5,7 +5,7 @@ using System.Linq;
 
 namespace AssetManagement.AssetHandling
 {
-    public class AssetManagementFactory : IAssetManagementFactory
+    public class AssetManagementFactory : IAssetImporterProvider
     {
         private readonly IEnumerable<IAssetImporter> _importers;
 

--- a/AssetManagment/AssetHandling/MeshImportExporter.cs
+++ b/AssetManagment/AssetHandling/MeshImportExporter.cs
@@ -5,11 +5,11 @@ using System.Linq;
 
 namespace AssetManagement.AssetHandling
 {
-    public class AssetManagementFactory : IAssetImporterProvider
+    public class AssetImporterProvider : IAssetImporterProvider
     {
         private readonly IEnumerable<IAssetImporter> _importers;
 
-        public AssetManagementFactory(IEnumerable<IAssetImporter> importers)
+        public AssetImporterProvider(IEnumerable<IAssetImporter> importers)
         {
             _importers = importers;
         }

--- a/AssetManagment/AssetManagement_DependencyInjectionContainer.cs
+++ b/AssetManagment/AssetManagement_DependencyInjectionContainer.cs
@@ -16,8 +16,8 @@ namespace AssetManagement
     {
         public override void Register(IServiceCollection serviceCollection)
         {
-            serviceCollection.AddScoped<IAssetManagementFactory, AssetManagementFactory>();
-            serviceCollection.AddTransient<IAssetImporter, FbxImportExport>();
+            serviceCollection.AddScoped<IAssetImporterProvider, AssetManagementFactory>();
+            serviceCollection.AddTransient<IAssetImporter, FbxAssetImporter>();
         }
     }
 }

--- a/AssetManagment/AssetManagement_DependencyInjectionContainer.cs
+++ b/AssetManagment/AssetManagement_DependencyInjectionContainer.cs
@@ -16,7 +16,7 @@ namespace AssetManagement
     {
         public override void Register(IServiceCollection serviceCollection)
         {
-            serviceCollection.AddScoped<IAssetImporterProvider, AssetManagementFactory>();
+            serviceCollection.AddScoped<IAssetImporterProvider, AssetImporterProvider>();
             serviceCollection.AddTransient<IAssetImporter, FbxAssetImporter>();
         }
     }

--- a/AssetManagment/MeshHandling/MeshImportExporter.cs
+++ b/AssetManagment/MeshHandling/MeshImportExporter.cs
@@ -5,7 +5,7 @@ using System.Linq;
 
 namespace AssetManagement.MeshHandling
 {
-    public class AssetManagementFactory : IAssetManagementFactory
+    public class AssetManagementFactory : IAssetImporterProvider
     {
         private readonly IEnumerable<IAssetImporter> _importers;
 

--- a/AssetManagment/Strategies/Fbx/FbxAssetImporter.cs
+++ b/AssetManagment/Strategies/Fbx/FbxAssetImporter.cs
@@ -9,18 +9,18 @@ using AssetManagement.AssetBuilders;
 
 namespace AssetManagement.Strategies.Fbx
 {
-    public class FbxImportExport : IAssetImporter
+    public class FbxAssetImporter : IAssetImporter
     {
         public string[] Formats => new string[] { ".fbx" };
 
         private readonly PackFileService _packFileService;
 
-        public FbxImportExport(PackFileService pfs)
+        public FbxAssetImporter(PackFileService pfs)
         {
             _packFileService = pfs;
         }
 
-        public PackFile ImportAsset(string diskFilePath)
+        public PackFile ImportAsset(string diskFilePath, AssetConfigData config=null)
         {
             var sceneContainer = SceneLoader.LoadScene(diskFilePath);
             if (sceneContainer == null)

--- a/CommonControls/Events/UiCommands/ImportAssetCommand.cs
+++ b/CommonControls/Events/UiCommands/ImportAssetCommand.cs
@@ -11,9 +11,9 @@ namespace CommonControls.Events.UiCommands
     public class ImportAssetCommand : IUiCommand
     {
         private readonly PackFileService _packFileService;
-        private readonly IAssetManagementFactory _assetManagementFactory;
+        private readonly IAssetImporterProvider _assetManagementFactory;
 
-        public ImportAssetCommand(PackFileService packFileService, IAssetManagementFactory assetManagementFactory)
+        public ImportAssetCommand(PackFileService packFileService, IAssetImporterProvider assetManagementFactory)
         {
             _packFileService = packFileService;
             _assetManagementFactory = assetManagementFactory;

--- a/CommonControls/Interfaces/AssetManagement/AssetConfigData.cs
+++ b/CommonControls/Interfaces/AssetManagement/AssetConfigData.cs
@@ -1,0 +1,47 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using CommonControls.FileTypes.Animation;
+using CommonControls.FileTypes.PackFiles.Models;
+using CommonControls.FileTypes.RigidModel;
+using CommonControls.FileTypes.WsModel;
+
+namespace CommonControls.Interfaces.AssetManagement
+{
+    public class AnimationSettingStruct
+    {
+        public float Fps { get; set; }
+        public float FrameCount { get; set; }
+        public float TimeEnd { get; set; }
+    }
+
+    enum UnitEnum
+    {
+        Meters,
+        Centimeters,
+        Millimeters,
+        Inches,
+        Feet,
+        Yards,
+        Miles,
+        Kilometers,
+        MilesScandinavian,
+        Decimeters,
+        Decameters,
+        Hectometers,
+        Microinches,
+        Mil,
+        Custom
+    }
+
+    /// <summary>
+    /// Configurations data, for C# mesh processors, and ultimately the (FBX) SDK saving the scene (.fbx) to disk
+    /// </summary>
+    public class AssetConfigData
+    {
+        float Scale { get; set; } = 1.0f;
+        UnitEnum SaveAsUnit { get; set; } = UnitEnum.Centimeters;
+        public AnimationSettingStruct AnimationSettings { get; set; } = new AnimationSettingStruct();
+    }
+}

--- a/CommonControls/Interfaces/AssetManagement/AssetManagerData.cs
+++ b/CommonControls/Interfaces/AssetManagement/AssetManagerData.cs
@@ -1,0 +1,31 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+
+using CommonControls.FileTypes.Animation;
+using CommonControls.FileTypes.PackFiles.Models;
+using CommonControls.FileTypes.RigidModel;
+using CommonControls.FileTypes.WsModel;
+
+namespace CommonControls.Interfaces.AssetManagement
+{
+    /// <summary>
+    /// All the data an import/export _might_ need
+    /// </summary>
+    public class AssetManagerData
+    {
+        public string DestinationPath { get; set; }
+        public string SourcePath { get; set; }
+        public byte[] BinaryDestinationFile { get; set; }
+        public byte[] BinarySourceFile { get; set; }
+        public PackFile InputPackFile { get; set; }
+        public PackFile OutputPackFile { get; set; }
+        public RmvFile RigidModelFile { set; get; }
+        public RmvModel[] Meshes { set; get; }
+        public WsMaterial[] wsModelFile { set; get; }
+        public string SkeletonName { get; set; }
+        public AnimationFile skeletonFile { set; get; }
+        public AnimationFile animationFile { set; get; }        
+    }
+}

--- a/CommonControls/Interfaces/AssetManagement/IAssetExporter.cs
+++ b/CommonControls/Interfaces/AssetManagement/IAssetExporter.cs
@@ -1,0 +1,12 @@
+﻿namespace CommonControls.Interfaces.AssetManagement
+{
+    /// <summary>
+    /// Asset Export Data - including all the data types the exporter might use          
+
+
+    public interface IAssetExporter
+    {
+        byte[] ExportAsset(AssetManagerData inputData, AssetConfigData config = null);
+        string[] Formats { get; }
+    }
+}

--- a/CommonControls/Interfaces/AssetManagement/IAssetExporterProvider.cs
+++ b/CommonControls/Interfaces/AssetManagement/IAssetExporterProvider.cs
@@ -2,13 +2,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using CommonControls.FileTypes.PackFiles.Models;
+using System.Collections.Generic;
 
 namespace CommonControls.Interfaces.AssetManagement
 {
-    public interface IAssetImporter
+    public interface IAssetExporterProvider
     {
-        PackFile ImportAsset(string diskFilePath, AssetConfigData config = null);
-        string[] Formats { get; }
+        List<IAssetExporter> GetAllExporters();
+        T GetExporter<T>() where T : IAssetExporter;
+        IAssetExporter GetExporter(string format);
     }
 }

--- a/CommonControls/Interfaces/AssetManagement/IAssetImporterProvider.cs
+++ b/CommonControls/Interfaces/AssetManagement/IAssetImporterProvider.cs
@@ -2,7 +2,7 @@
 
 namespace CommonControls.Interfaces.AssetManagement
 {
-    public interface IAssetManagementFactory
+    public interface IAssetImporterProvider
     {
         List<IAssetImporter> GetAllImporters();
         T GetImporter<T>() where T : IAssetImporter;


### PR DESCRIPTION
Adds the basic interfaces and classes needed for adding (FBX) export.
Doesn't change the **basic** functionality, as that was already int there (see diagram)

### Changes:
- `IAssetManagementFactory` becomes `IAssetImportProvider` and  `IAssetExporterProvider`  as `IAssetManagementFactory` only had import support, and I do not know the intent for it. The 2 new interfaces works exactly the same way as the old one.

- ` IAssetImportProvider`/IAssetExporterProvider` provides `IAssetImporter` / `IAssetExporter`  respectvely, based on extension as before

- `IAssetExporter.ExportAsset(()` has  params for all _potential_ input data , AND config data which comes from the  UI

Data Flow Diagram
[Data Flow Diagram - AssetEditor FBX Export With Materials - Revision 3.pdf](https://github.com/donkeyProgramming/TheAssetEditor/files/13283071/Data.Flow.Diagram.-.AssetEditor.FBX.Export.With.Materials.-.Revision.3.pdf)
