### PR TITLE
C# utlity classes for export. (Bottom-up)

### DIFF
--- a/AssetManagment/AnimationProcessing/SkeletonHelper.cs
+++ b/AssetManagment/AnimationProcessing/SkeletonHelper.cs
@@ -1,0 +1,56 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Linq;
+using CommonControls.FileTypes.Animation;
+
+namespace AssetManagement.AnimationProcessor
+{
+    public class SkeletonHelper
+    {
+        /// <summary>
+        /// Get .ANIM bone name associate with RMV2 vertex bone id/index
+        /// </summary>        
+        static public int GetIdFromBoneName(AnimationFile skeleton, string name)
+        {
+            var boneInfo = skeleton.Bones
+                .Where(x => string.Compare(x.Name, name, StringComparison.InvariantCultureIgnoreCase) == 0)
+                .FirstOrDefault();
+
+            return (boneInfo == null) ? -1 : boneInfo.Id;
+        }
+
+        /// <summary>
+        /// Safe method for looking up bones, as opposed to using the bone index directly, avoid accidental overflow
+        /// </summary>
+        static public string GetBoneNameFromId(AnimationFile skeleton, int boneIndex)
+        {
+            return (boneIndex >= skeleton.Bones.Length) ? "" : skeleton.Bones[boneIndex].Name;
+        }
+
+        /// <summary>
+        /// Determines if the file contains a skeleton (or an anim clip)
+        /// </summary>        
+        static public bool IsFileSkeleton(AnimationFile skeletonFile)
+        {
+            var boneCount = skeletonFile.Bones.Length;
+
+            if (!skeletonFile.AnimationParts.Any() || !skeletonFile.AnimationParts[0].DynamicFrames.Any())
+            {
+                return false;
+            }
+
+            var frame0 = skeletonFile.AnimationParts[0].DynamicFrames[0];
+
+            // a skeleton has geomtry data for all bones at frame 0
+            if (frame0.Quaternion.Count == frame0.Transforms.Count && boneCount == frame0.Quaternion.Count)
+            {
+                return true;
+            }
+
+            return false;
+        }
+    }
+}

--- a/AssetManagment/AssetBuilders/PackMeshBuilderHelpers.cs
+++ b/AssetManagment/AssetBuilders/PackMeshBuilderHelpers.cs
@@ -1,0 +1,36 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using AssetManagement.GenericFormats.DataStructures.Unmanaged;
+using CommonControls.FileTypes.RigidModel.Vertex;
+
+namespace AssetManagement.AssetBuilders
+{
+    internal static class PackedVertexHelper
+    {
+        internal static ExtPackedCommonVertex CreateExtPackedVertex(CommonVertex inVertex)
+        {
+            var outVertex = new ExtPackedCommonVertex();
+
+            outVertex.Position.x = inVertex.Position.X;
+            outVertex.Position.y = inVertex.Position.Y;
+            outVertex.Position.z = inVertex.Position.Z;
+            outVertex.Position.w = inVertex.Position.W;
+
+            outVertex.Uv.x = inVertex.Uv.X;
+            outVertex.Uv.y = inVertex.Uv.Y;
+
+            outVertex.Normal.x = inVertex.Normal.X;
+            outVertex.Normal.y = inVertex.Normal.Y;
+            outVertex.Normal.z = inVertex.Normal.Z;
+
+            return outVertex;
+        }
+    }
+}

--- a/AssetManagment/AssetBuilders/VertexWeightCreator.cs
+++ b/AssetManagment/AssetBuilders/VertexWeightCreator.cs
@@ -1,0 +1,74 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+
+using System.Collections.Generic;
+using CommonControls.FileTypes.Animation;
+using CommonControls.FileTypes.RigidModel.Vertex;
+using CommonControls.FileTypes.RigidModel;
+using AssetManagement.GenericFormats.DataStructures.Unmanaged;
+
+namespace AssetManagement.AssetBuilders
+{
+    /// <summary>
+    /// Creats per-vers inclueces from RMV2 weights
+    /// so weights are a unested array, easy to transer/copy
+    /// </summary>
+    class VertexWeightCreator
+    {
+        private readonly AnimationFile _skeletonFile;
+        private readonly RmvModel _inModel;
+        private readonly List<ExtVertexWeight> _vertexTempVertexWeights = new List<ExtVertexWeight>();
+
+        private VertexWeightCreator() { }
+        public VertexWeightCreator(RmvModel inModel, AnimationFile skeletonFile)
+        {
+            _inModel = inModel;
+            _skeletonFile = skeletonFile;
+        }
+
+        public List<ExtVertexWeight> CreateVertexWeigts()
+        {
+            AddVertexWeights();
+
+            return _vertexTempVertexWeights;
+        }
+
+        private void AddVertexWeights()
+        {
+            for (int vertexBufferIndex = 0; vertexBufferIndex < _inModel.Mesh.VertexList.Length; vertexBufferIndex++)
+            {
+                AddCornerWeights(_inModel.Mesh.VertexList[vertexBufferIndex], (uint)vertexBufferIndex);
+            }
+        }
+
+        private void AddCornerWeights(CommonVertex inVertex, uint newVertexIndex)
+        {
+            // add as many weights as is stored in the RMVmodel vertex, 
+            for (uint weightIndex = 0; weightIndex < inVertex.WeightCount; weightIndex++)
+            {
+                // CA Rule: Duplicate bone indices are "illegal", and are used as "terminators" to indicate weight count                               
+                if (weightIndex > 0 && inVertex.BoneIndex[0] == inVertex.BoneIndex[weightIndex])
+                {
+                    continue; // skip these as they will cause problems in the SKD, as the add duplicate bones/vertex
+                }
+
+                if (inVertex.BoneIndex[weightIndex] == 0.0f)
+                {
+                    continue; // avoid null weight, as then also cause issues also cause issues
+                }
+
+                var vertexWeight = new ExtVertexWeight()
+                {
+                    vertexIndex = newVertexIndex,
+                    boneName = _skeletonFile.GetBoneNameFromIndex(inVertex.BoneIndex[weightIndex]),
+                    boneIndex = inVertex.BoneIndex[weightIndex],
+                    weight = inVertex.BoneWeight[weightIndex],
+                };
+
+                _vertexTempVertexWeights.Add(vertexWeight);
+            };
+        }
+    }
+}

--- a/AssetManagment/AssetBuilders/VertexWeightCreator.cs
+++ b/AssetManagment/AssetBuilders/VertexWeightCreator.cs
@@ -8,6 +8,7 @@ using CommonControls.FileTypes.Animation;
 using CommonControls.FileTypes.RigidModel.Vertex;
 using CommonControls.FileTypes.RigidModel;
 using AssetManagement.GenericFormats.DataStructures.Unmanaged;
+using AssetManagement.AnimationProcessor;
 
 namespace AssetManagement.AssetBuilders
 {
@@ -62,7 +63,7 @@ namespace AssetManagement.AssetBuilders
                 var vertexWeight = new ExtVertexWeight()
                 {
                     vertexIndex = newVertexIndex,
-                    boneName = _skeletonFile.GetBoneNameFromIndex(inVertex.BoneIndex[weightIndex]),
+                    boneName = SkeletonHelper.GetBoneNameFromId(_skeletonFile, inVertex.BoneIndex[weightIndex]),                    
                     boneIndex = inVertex.BoneIndex[weightIndex],
                     weight = inVertex.BoneWeight[weightIndex],
                 };

--- a/AssetManagment/MeshProcessing/Common/CommonWeightProcessor.cs
+++ b/AssetManagment/MeshProcessing/Common/CommonWeightProcessor.cs
@@ -6,6 +6,7 @@ using CommonControls.FileTypes.Animation;
 using AssetManagement.GenericFormats.DataStructures.Managed;
 using CommonControls.Common;
 using Serilog;
+using AssetManagement.AnimationProcessor;
 
 namespace AssetManagement.MeshProcessing.Common
 {
@@ -33,7 +34,7 @@ namespace AssetManagement.MeshProcessing.Common
         {
             if (boneName.Any()) // don't add empty influences (boneName == "")
             {
-                var boneIndex = skeletonFile.GetIdFromBoneName(boneName);
+                var boneIndex = SkeletonHelper.GetIdFromBoneName(skeletonFile, boneName);
 
                 if (boneIndex == AnimationFile.InvalidBoneIndex)
                 {

--- a/AssetManagment/MeshProcessing/Packed/PackedMeshProcessor.cs
+++ b/AssetManagment/MeshProcessing/Packed/PackedMeshProcessor.cs
@@ -6,6 +6,7 @@ using System;
 using CommonControls.FileTypes.Animation;
 using AssetManagement.GenericFormats.DataStructures.Managed;
 using System.Linq;
+using AssetManagement.AnimationProcessor;
 
 namespace AssetManagement.MeshProcessing.Packed
 {
@@ -21,7 +22,7 @@ namespace AssetManagement.MeshProcessing.Packed
         public static bool CompareMeshVertexWeigtBonesToSkeleton(PackedMesh mesh, AnimationFile animationFile)
         {
             // TODO: TEST THIS
-            if (mesh.VertexWeights.Any(weight => animationFile.GetIdFromBoneName(weight.boneName) == -1))
+            if (mesh.VertexWeights.Any(weight => SkeletonHelper.GetIdFromBoneName(animationFile, weight.boneName) == -1))
                 return false;
 
             return true;

--- a/CommonControls/FileTypes/Animation/AnimationFile.cs
+++ b/CommonControls/FileTypes/Animation/AnimationFile.cs
@@ -181,8 +181,16 @@ namespace CommonControls.FileTypes.Animation
             var boneInfo = Bones
                 .Where(x => string.Compare(x.Name, name, StringComparison.InvariantCultureIgnoreCase) == 0)
                 .FirstOrDefault();
-                            
+
             return (boneInfo == null) ? -1 : boneInfo.Id;
+        }
+
+        /// <summary>
+        /// Safe method for looking up bones, as opposed to using the bone index directly
+        /// </summary>
+        public string GetBoneNameFromIndex(int boneIndex)
+        {
+            return (boneIndex >= Bones.Length) ? "" : Bones[boneIndex].Name;
         }
 
         public static AnimationFile Create(PackFile file)

--- a/CommonControls/FileTypes/Animation/AnimationFile.cs
+++ b/CommonControls/FileTypes/Animation/AnimationFile.cs
@@ -176,23 +176,6 @@ namespace CommonControls.FileTypes.Animation
             return header;
         }
 
-        public int GetIdFromBoneName(string name)
-        {
-            var boneInfo = Bones
-                .Where(x => string.Compare(x.Name, name, StringComparison.InvariantCultureIgnoreCase) == 0)
-                .FirstOrDefault();
-
-            return (boneInfo == null) ? -1 : boneInfo.Id;
-        }
-
-        /// <summary>
-        /// Safe method for looking up bones, as opposed to using the bone index directly
-        /// </summary>
-        public string GetBoneNameFromIndex(int boneIndex)
-        {
-            return (boneIndex >= Bones.Length) ? "" : Bones[boneIndex].Name;
-        }
-
         public static AnimationFile Create(PackFile file)
         {
             ILogger logger = Logging.Create<AnimationFile>();


### PR DESCRIPTION
Add; 
- `PackedMeshBuilder `updated to be more S.O.L.I.D, it is now "open closed". Its interface `IPackedMeshBuilder `has two implementations, `IndexedPackedMeshBuilder`, and `WeightedIndexedPackedMeshBuilder`.  the scene builder uses
`PackedMeshBuilderFactory.GetBuilder(AnimationFile skeletonFile)` to obtain the riggedd of non-rigged version as needed.

- `VertexWeightCreator` is used  to copy the 1-4 weights in an RMV2 vertex to 1 un-nested array, 

- Added  `Animations.GetIdFromBoneName(string name)` for save lookups (not out of range),  AnimationFile already has `string GetBoneNameFromId(int id)

- 2-3 minor helper classes
