### PR TITLE
Animation validator & Embedded Resource Loader Fix

### DIFF
--- a/Editors/KitbasherEditor/ViewModels/SceneExplorerNodeViews/Rmv2/MaterialGeneralViewModel.TextureViewModel.cs
+++ b/Editors/KitbasherEditor/ViewModels/SceneExplorerNodeViews/Rmv2/MaterialGeneralViewModel.TextureViewModel.cs
@@ -5,6 +5,7 @@ using System.ComponentModel;
 using System.Linq;
 using System.Windows;
 using CommonControls.PackFileBrowser;
+using Shared.Core.Events;
 using Shared.Core.Misc;
 using Shared.Core.PackFiles;
 using Shared.GameFormats.RigidModel.Types;
@@ -19,6 +20,7 @@ namespace KitbasherEditor.ViewModels.SceneExplorerNodeViews.Rmv2
         {
             PackFileService _packfileService;
             Rmv2MeshNode _meshNode;
+            EventHub _eventHub;
             public TextureType TexureType { get; private set; }
 
             bool _useTexture = true;
@@ -46,9 +48,10 @@ namespace KitbasherEditor.ViewModels.SceneExplorerNodeViews.Rmv2
             private readonly Dictionary<string, List<string>> _errorsByPropertyName = new Dictionary<string, List<string>>();
             private string _path = "";
 
-            public TextureViewModel(Rmv2MeshNode meshNode, PackFileService packfileService, TextureType texureType)
+            public TextureViewModel(Rmv2MeshNode meshNode, PackFileService packfileService, TextureType texureType, EventHub eventHub)
             {
                 _packfileService = packfileService;
+                _eventHub = eventHub;
                 _meshNode = meshNode;
                 TexureType = texureType;
                 TextureTypeStr = TexureType.ToString();
@@ -68,7 +71,7 @@ namespace KitbasherEditor.ViewModels.SceneExplorerNodeViews.Rmv2
                 UpdateTexturePath(path);
 
             }
-            public void Preview() => TexturePreviewController.CreateWindow(Path, _packfileService);
+            public void Preview() => TexturePreviewController.CreateWindow(Path, _packfileService, _eventHub);
 
             public void Browse()
             {

--- a/Editors/KitbasherEditor/ViewModels/SceneExplorerNodeViews/Rmv2/MaterialGeneralViewModel.cs
+++ b/Editors/KitbasherEditor/ViewModels/SceneExplorerNodeViews/Rmv2/MaterialGeneralViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using CommunityToolkit.Mvvm.Input;
+using Shared.Core.Events;
 using Shared.Core.Misc;
 using Shared.Core.PackFiles;
 using Shared.Core.Services;
@@ -20,6 +21,7 @@ namespace KitbasherEditor.ViewModels.SceneExplorerNodeViews.Rmv2
         private readonly Rmv2MeshNode _meshNode;
         private readonly PackFileService _pfs;
         private readonly ApplicationSettingsService _applicationSettingsService;
+        private readonly EventHub _eventHub;
 
         public ICommand ResolveTexturesCommand { get; set; }
         public ICommand DeleteMissingTexturesCommand { get; set; }
@@ -55,11 +57,12 @@ namespace KitbasherEditor.ViewModels.SceneExplorerNodeViews.Rmv2
         public UiVertexFormat VertexType { get { return _meshNode.Geometry.VertexFormat; } set { ChangeVertexType(value); } }
         public IEnumerable<UiVertexFormat> PossibleVertexTypes { get; set; }
 
-        public MaterialGeneralViewModel(KitbasherRootScene kitbasherRootScene, Rmv2MeshNode meshNode, PackFileService pfs,  ApplicationSettingsService applicationSettings)
+        public MaterialGeneralViewModel(KitbasherRootScene kitbasherRootScene, Rmv2MeshNode meshNode, PackFileService pfs,  ApplicationSettingsService applicationSettings, EventHub eventHub)
         {
             _kitbasherRootScene = kitbasherRootScene;
             _meshNode = meshNode;
             _pfs = pfs;
+            _eventHub = eventHub;
             _applicationSettingsService = applicationSettings;
             PossibleVertexTypes = new UiVertexFormat[] { UiVertexFormat.Static, UiVertexFormat.Weighted, UiVertexFormat.Cinematic };
             ResolveTexturesCommand = new RelayCommand(ResolveMissingTextures);
@@ -78,7 +81,7 @@ namespace KitbasherEditor.ViewModels.SceneExplorerNodeViews.Rmv2
             TextureList.Clear();
             foreach (var enumValue in distinctEnumList)
             {
-                var textureView = new TextureViewModel(_meshNode, _pfs, enumValue);
+                var textureView = new TextureViewModel(_meshNode, _pfs, enumValue,_eventHub);
                 TextureList.Add(textureView);
             }
 

--- a/Editors/KitbasherEditor/ViewModels/SceneExplorerNodeViews/Rmv2/MeshEditorViewModel.cs
+++ b/Editors/KitbasherEditor/ViewModels/SceneExplorerNodeViews/Rmv2/MeshEditorViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using Editors.Shared.Core.Services;
+using Shared.Core.Events;
 using Shared.Core.Misc;
 using Shared.Core.PackFiles;
 using Shared.Core.Services;
@@ -15,11 +16,11 @@ namespace KitbasherEditor.ViewModels.SceneExplorerNodeViews.Rmv2
         public MaterialGeneralViewModel MaterialGeneral { get; set; }
         public WeightedMaterialViewModel Material { get; set; }
 
-        public MeshEditorViewModel(KitbasherRootScene kitbasherRootScene, Rmv2MeshNode node, PackFileService pfs, SkeletonAnimationLookUpHelper animLookUp, SceneManager sceneManager, ApplicationSettingsService applicationSettings)
+        public MeshEditorViewModel(KitbasherRootScene kitbasherRootScene, Rmv2MeshNode node, PackFileService pfs, SkeletonAnimationLookUpHelper animLookUp, SceneManager sceneManager, ApplicationSettingsService applicationSettings, EventHub eventHub)
         {
             Mesh = new MeshViewModel(node, sceneManager);
             Animation = new AnimationViewModel(kitbasherRootScene, node, pfs, animLookUp);
-            MaterialGeneral = new MaterialGeneralViewModel(kitbasherRootScene, node, pfs, applicationSettings);
+            MaterialGeneral = new MaterialGeneralViewModel(kitbasherRootScene, node, pfs, applicationSettings, eventHub);
 
             if (node.Material is WeightedMaterial)
                 Material = new WeightedMaterialViewModel(node);

--- a/Editors/KitbasherEditor/ViewModels/SceneExplorerNodeViews/SceneNodeViewFactory.cs
+++ b/Editors/KitbasherEditor/ViewModels/SceneExplorerNodeViews/SceneNodeViewFactory.cs
@@ -1,5 +1,6 @@
 ﻿using Editors.Shared.Core.Services;
 using KitbasherEditor.ViewModels.SceneExplorerNodeViews.Rmv2;
+using Shared.Core.Events;
 using Shared.Core.PackFiles;
 using Shared.Core.Services;
 using View3D.Components.Component;
@@ -17,13 +18,15 @@ namespace KitbasherEditor.ViewModels.SceneExplorerNodeViews
         private readonly PackFileService _packFileService;
         private readonly ApplicationSettingsService _applicationSettingsService;
         private readonly RenderEngineComponent _renderEngineComponent;
+        private readonly EventHub _eventHub;
 
         public SceneNodeViewFactory(SceneManager sceneManager,
             KitbasherRootScene kitbasherRootScene, 
             SkeletonAnimationLookUpHelper skeletonAnimationLookUpHelper, 
             PackFileService packFileService, 
             ApplicationSettingsService applicationSettingsService,
-            RenderEngineComponent renderEngineComponent)
+            RenderEngineComponent renderEngineComponent,
+            EventHub eventHub)
         {
             _sceneManager = sceneManager;
             _kitbasherRootScene = kitbasherRootScene;
@@ -31,6 +34,7 @@ namespace KitbasherEditor.ViewModels.SceneExplorerNodeViews
             _packFileService = packFileService;
             _applicationSettingsService = applicationSettingsService;
             _renderEngineComponent = renderEngineComponent;
+            _eventHub = eventHub;
         }
 
         public ISceneNodeViewModel CreateEditorView(ISceneNode node)
@@ -40,7 +44,7 @@ namespace KitbasherEditor.ViewModels.SceneExplorerNodeViews
                 case MainEditableNode mainNode:
                     return new MainEditableNodeViewModel(_kitbasherRootScene, mainNode, _skeletonAnimationLookUpHelper, _packFileService, _renderEngineComponent);
                 case Rmv2MeshNode m:
-                    return new MeshEditorViewModel(_kitbasherRootScene, m, _packFileService, _skeletonAnimationLookUpHelper, _sceneManager, _applicationSettingsService);
+                    return new MeshEditorViewModel(_kitbasherRootScene, m, _packFileService, _skeletonAnimationLookUpHelper, _sceneManager, _applicationSettingsService, _eventHub);
                 case SkeletonNode s:
                     return new SkeletonSceneNodeViewModel(s, _packFileService, _skeletonAnimationLookUpHelper);
                 case GroupNode n:

--- a/Editors/SimpleAnimationEditors/AnimationPack/AnimPackViewModel.cs
+++ b/Editors/SimpleAnimationEditors/AnimationPack/AnimPackViewModel.cs
@@ -174,6 +174,8 @@ namespace CommonControls.Editors.AnimationPack
                 MessageBox.Show("Can not save in this mode - Open the file normally");
                 return false;
             }
+            var converter = (AnimationBinWh3FileToXmlConverter)_activeConverter;
+            converter.AnimPackToValidate = _packFile;
 
             var fileName = AnimationPackItems.SelectedItem.FileName;
             var bytes = _activeConverter.ToBytes(SelectedItemViewModel.Text, fileName, _pfs, out var error);

--- a/Editors/SimpleAnimationEditors/AnimationPack/Converters/AnimationBinWh3FileToXmlConverter.cs
+++ b/Editors/SimpleAnimationEditors/AnimationPack/Converters/AnimationBinWh3FileToXmlConverter.cs
@@ -125,6 +125,7 @@ namespace CommonControls.Editors.AnimationPack.Converters
             return binFile.ToByteArray();
         }
 
+
         protected override ITextConverter.SaveError Validate(XmlFormat type, string s, PackFileService pfs, string filepath)
         {
             try
@@ -192,8 +193,10 @@ namespace CommonControls.Editors.AnimationPack.Converters
                             errorList.Warning(animation.Slot, $"Animation file {animationRef.File} is not found");
                         else if (!IsAnimFile(animationRef.File, pfs))
                             errorList.Error(animation.Slot, $"Animation file {animationRef.File} does not appears to be a valid animation file");
+                        else if (String.IsNullOrWhiteSpace(animationRef.File))
+                            errorList.Error(animation.Slot, $"Animation file {animationRef.File} contain whitespace which could trigger a tpose");
                         else
-                            ValidateAnimationVersionAgainstPersistenceMeta(animationRef.File, animation.Slot, pfs, errorList);
+                            ValidateAnimationVersionAgainstPersistenceMeta(animationRef.File, animation.Slot, type.Data.SkeletonName, pfs, errorList);
 
                         if (pfs.FindFile(animationRef.Meta) == null)
                             errorList.Warning(animation.Slot, $"Meta file {animationRef.Meta} is not found");
@@ -201,18 +204,19 @@ namespace CommonControls.Editors.AnimationPack.Converters
                             errorList.Error(animation.Slot, $"Meta file {animationRef.Meta} does not appear to be a valid meta animation");
                         else
                         {
-                            CheckForAnimationVersionsInMeta(animationRef.File, animationRef.Meta, animation.Slot, pfs, errorList);
-                            var mountBin = type.Data.MountBin;
-                            CheckForRiderAndHisMountAnimationsVersion(mountBin, AnimPackToValidate, animation.Slot, animationRef.File, pfs, errorList); ;
+                            CheckForAnimationVersionsInMeta(animationRef.File, animationRef.Meta, animation.Slot, type.Data.SkeletonName, pfs, errorList);
                         }
+
+                        var mountBin = type.Data.MountBin;
+                        CheckForRiderAndHisMountAnimationsVersion(mountBin, AnimPackToValidate, animation.Slot, animationRef.File, pfs, errorList);
 
                         if (pfs.FindFile(animationRef.Sound) == null)
                             errorList.Warning(animation.Slot, $"Sound file {animationRef.Sound} is not found");
                         else if (!IsSndMetaFile(animationRef.Sound, pfs))
                             errorList.Error(animation.Slot, $"Sound file {animationRef.Sound} does not appear to be a valid meta sound");
+
                     }
                 }
-
 
                 if (errorList.Errors.Count != 0)
                     ErrorListWindow.ShowDialog("Errors", errorList, false);
@@ -254,7 +258,7 @@ namespace CommonControls.Editors.AnimationPack.Converters
             return endsWithDotMeta && headerIsReallyAnimMetaFile;
         }
 
-        private bool CheckForAnimationVersionsInMeta(string mainAnimationFile, string metaFile, string animationSlot, PackFileService pfs, ErrorList errorList)
+        private bool CheckForAnimationVersionsInMeta(string mainAnimationFile, string metaFile, string animationSlot, string skeleton, PackFileService pfs, ErrorList errorList)
         {
             var result = true;
 
@@ -293,13 +297,22 @@ namespace CommonControls.Editors.AnimationPack.Converters
                         if (mainAnimationVersion == 8 && animationVersion == 5) continue; //no idea why this isn't problem in vanilla wh3
 
                         var isTheVersionMatch = animationVersion == mainAnimationVersion;
+                        var isMatchedCombat = animationSlot.StartsWith("COMBAT_");
+                        var isMountedAnim = animationSlot.StartsWith("RIDER_") && skeleton.Contains("humanoid");
 
-                        if (!isTheVersionMatch)
+                        if (isMatchedCombat) continue;
+                        if (!isMountedAnim) continue;
+                        if (isTheVersionMatch) continue;
+
                         {
                             errorList.Error(animationSlot, $"Animation Meta Splice {metaFile} has different version than in the main animation. File referenced in meta: {animPath} with version {animationVersion} vs in the main animation {mainAnimationFile} with version {mainAnimationVersion}");
                             result = false;
                         }
                     }
+                }
+                else if (item.DisplayName.Contains("DISABLE_PER") && animationSlot.StartsWith("RIDER_"))
+                {
+                    errorList.Warning(animationSlot, $"Contains DISABLE_PERSISTENCE which could cause sync rider animation. In metafile: {metaFile}");
                 }
 
 
@@ -308,7 +321,7 @@ namespace CommonControls.Editors.AnimationPack.Converters
             return result;
         }
 
-        private bool ValidateAnimationVersionAgainstPersistenceMeta(string mainAnimationFile, string animationSlot, PackFileService pfs, ErrorList errorList)
+        private bool ValidateAnimationVersionAgainstPersistenceMeta(string mainAnimationFile, string animationSlot, string skeleton, PackFileService pfs, ErrorList errorList)
         {
             var versions = AnimationsVersionFoundInPersistenceMeta;
             var result = true;
@@ -317,12 +330,22 @@ namespace CommonControls.Editors.AnimationPack.Converters
             var mainAnimationParsed = AnimationFile.Create(mainAnimation);
             var mainAnimationVersion = mainAnimationParsed.Header.Version;
 
-            foreach (var (path, version) in versions)
+
+            foreach (var (animPath, animationVersion) in versions)
             {
-                if (version == mainAnimationVersion) continue;
-                else
+                if (mainAnimationVersion == 5 && animationVersion == 8) continue; //no idea why this isn't problem in vanilla wh3
+                if (mainAnimationVersion == 8 && animationVersion == 5) continue; //no idea why this isn't problem in vanilla wh3
+
+                var isTheVersionMatch = animationVersion == mainAnimationVersion;
+                var isMatchedCombat = animationSlot.StartsWith("COMBAT_");
+                var isMountedAnim = animationSlot.StartsWith("RIDER_") && skeleton.Contains("humanoid");
+
+                if (isMatchedCombat) continue;
+                if (!isMountedAnim) continue;
+                if (isTheVersionMatch) continue;
+
                 {
-                    errorList.Error(animationSlot, $"Animation Meta Splice {AnimationPersistanceMetaFileName} has different version than in the main animation. File referenced in meta: {path} with version {version} vs in the main animation {mainAnimationFile} with version {mainAnimationVersion}");
+                    errorList.Error(animationSlot, $"Animation Meta Splice {AnimationPersistanceMetaFileName} has different version than in the main animation. File referenced in meta: {animPath} with version {animationVersion} vs in the main animation {mainAnimationFile} with version {mainAnimationVersion}");
                     result = false;
                 }
             }
@@ -352,24 +375,48 @@ namespace CommonControls.Editors.AnimationPack.Converters
             var animations = parsedBin.Animations;
 
             var riderAnimationSlotWithoutPrefix = animationSlot.Substring(6);
-            var mainAnimationToCompareVersion = GetAnimationHeader(animationFile, pfs).Version;
+            var mainAnimationToCompareHeader = GetAnimationHeader(animationFile, pfs);
+            var mainAnimationToCompareVersion = mainAnimationToCompareHeader.Version;
+            var mainAnimationToData = GetAnimationData(animationFile, pfs);
+            var mainAnimationLength = mainAnimationToData.AnimationParts[0].DynamicFrames.Count;
+            var mainAnimationTime = mainAnimationToCompareHeader.AnimationTotalPlayTimeInSec;
+
 
             foreach (var anim in animations)
             {
-                if (!anim.Slot.Contains(riderAnimationSlotWithoutPrefix)) continue;
+                if (anim.Slot != riderAnimationSlotWithoutPrefix) continue;
 
                 var animationInstances = anim.Ref;
                 foreach (var animationInstance in animationInstances)
                 {
-                    var version = GetAnimationHeader(animationInstance.File, pfs).Version;
+                    var header = GetAnimationHeader(animationInstance.File, pfs);
+
+                    var version = header.Version;
                     var isVersionMatch = version == mainAnimationToCompareVersion;
                     if (!isVersionMatch)
                     {
                         errorList.Error(animationSlot, $"Rider animation version mismatch with mount animation. Mount animation {animationInstance.File} with version {version} vs in the main animation {animationFile} with version {mainAnimationToCompareVersion}");
                         result = false;
                     }
-                }
 
+                    var timing = header.AnimationTotalPlayTimeInSec;
+                    var data = GetAnimationData(animationInstance.File, pfs);
+                    var length = data.AnimationParts[0].DynamicFrames.Count;
+
+                    var isTImingMatch = mainAnimationTime == timing;
+                    if (!isTImingMatch)
+                    {
+                        errorList.Error(animationSlot, $"Rider animation mismatch with mount timing  animation. Mount animation {animationInstance.File} with timing {timing} vs in the main animation {animationFile} with timing {mainAnimationTime}");
+                        result = false;
+                    }
+
+                    var isLenMatch = mainAnimationLength == length;
+                    if (!isLenMatch)
+                    {
+                        errorList.Error(animationSlot, $"Rider animation mismatch with mount frames animation. Mount animation {animationInstance.File} with length {length} vs in the main animation {animationFile} with timing {mainAnimationLength}");
+                        result = false;
+                    }
+                }
             }
 
             return result;
@@ -381,6 +428,13 @@ namespace CommonControls.Editors.AnimationPack.Converters
             var mainAnimation = pfs.FindFile(path);
             var mainAnimationParsed = AnimationFile.Create(mainAnimation);
             return mainAnimationParsed.Header;
+        }
+
+        private AnimationFile GetAnimationData(string path, PackFileService pfs)
+        {
+            var mainAnimation = pfs.FindFile(path);
+            var mainAnimationParsed = AnimationFile.Create(mainAnimation);
+            return mainAnimationParsed;
         }
 
 

--- a/Editors/SimpleAnimationEditors/AnimationPack/Converters/AnimationBinWh3FileToXmlConverter.cs
+++ b/Editors/SimpleAnimationEditors/AnimationPack/Converters/AnimationBinWh3FileToXmlConverter.cs
@@ -2,6 +2,7 @@
 using System.Xml;
 using System.Xml.Serialization;
 using CommonControls.BaseDialogs.ErrorListDialog;
+using CsvHelper;
 using Editors.Shared.Core.Services;
 using Shared.Core.ErrorHandling;
 using Shared.Core.PackFiles;
@@ -267,7 +268,14 @@ namespace CommonControls.Editors.AnimationPack.Converters
             var data = theFile.DataSource.ReadData();
             var parsed = new MetaDataFileParser().ParseFile(data);
 
-            var mainAnimationVersion = GetAnimationHeader(mainAnimationFile, pfs).Version;
+            var mainAnimationHeader = GetAnimationHeader(mainAnimationFile, pfs);
+            if (mainAnimationHeader == null)
+            {
+                errorList.Error(animationSlot, $"Cannot locate animation {mainAnimationFile} while trying to parse meta");
+                return false;
+            }
+
+            var mainAnimationVersion = mainAnimationHeader.Version;
 
             var metaItems = parsed.Items;
 
@@ -426,6 +434,7 @@ namespace CommonControls.Editors.AnimationPack.Converters
         private AnimationFile.AnimationHeader GetAnimationHeader(string path, PackFileService pfs)
         {
             var mainAnimation = pfs.FindFile(path);
+            if (mainAnimation == null) return null;
             var mainAnimationParsed = AnimationFile.Create(mainAnimation);
             return mainAnimationParsed.Header;
         }

--- a/Editors/SimpleAnimationEditors/AnimationPack/Converters/BaseAnimConverter.cs
+++ b/Editors/SimpleAnimationEditors/AnimationPack/Converters/BaseAnimConverter.cs
@@ -5,6 +5,7 @@ using System.Xml;
 using System.Xml.Serialization;
 using Shared.Core.ErrorHandling;
 using Shared.Core.PackFiles;
+using Shared.Core.PackFiles.Models;
 using Shared.Ui.Editors.TextEditor;
 
 namespace CommonControls.Editors.AnimationPack.Converters
@@ -16,6 +17,8 @@ namespace CommonControls.Editors.AnimationPack.Converters
         public bool ShouldShowLineNumbers() => true;
         public string GetSyntaxType() => "XML";
         public bool CanSaveOnError() => false;
+
+        public PackFile AnimPackToValidate = null;
 
         protected abstract ITextConverter.SaveError Validate(XmlType type, string s, PackFileService pfs, string filepath);
         protected abstract XmlType ConvertBytesToXmlClass(byte[] bytes);

--- a/Editors/TextureEditor/ViewModels/TextureEditorViewModel.cs
+++ b/Editors/TextureEditor/ViewModels/TextureEditorViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Shared.Core.Events;
 using Shared.Core.Misc;
 using Shared.Core.PackFiles;
 using Shared.Core.PackFiles.Models;
@@ -11,6 +12,7 @@ namespace TextureEditor.ViewModels
         PackFileService _pfs;
         PackFile _file;
         TexturePreviewController _controller;
+        EventHub _eventHub;
 
         public NotifyAttr<string> DisplayName { get; set; } = new NotifyAttr<string>();
 
@@ -25,9 +27,10 @@ namespace TextureEditor.ViewModels
             set => SetAndNotify(ref _viewModel, value);
         }
 
-        public TextureEditorViewModel(PackFileService pfs)
+        public TextureEditorViewModel(PackFileService pfs, EventHub eventHub)
         {
             _pfs = pfs;
+            _eventHub = eventHub;
         }
 
         public void Load(PackFile file)
@@ -38,7 +41,7 @@ namespace TextureEditor.ViewModels
             var viewModel = new TexturePreviewViewModel();
             viewModel.ImagePath.Value = _pfs.GetFullPath(file);
 
-            _controller = new TexturePreviewController(_pfs.GetFullPath(file), viewModel, _pfs);
+            _controller = new TexturePreviewController(_pfs.GetFullPath(file), viewModel, _pfs, _eventHub);
             ViewModel = viewModel;
         }
 

--- a/Editors/TextureEditor/ViewModels/TexturePreviewController.cs
+++ b/Editors/TextureEditor/ViewModels/TexturePreviewController.cs
@@ -7,6 +7,7 @@ using System.Windows;
 using System.Windows.Media.Imaging;
 using CommonControls.BaseDialogs;
 using Microsoft.Xna.Framework.Graphics;
+using Shared.Core.Events;
 using Shared.Core.Misc;
 using Shared.Core.PackFiles;
 using TextureEditor.Views;
@@ -24,6 +25,7 @@ namespace TextureEditor.ViewModels
         private readonly string _imagePath;
         private readonly TexturePreviewViewModel _viewModel;
         private readonly GameWorld _scene;
+        private readonly EventHub _eventHub;
 
         public class ViewModelWrapper : NotifyPropertyChangedImpl
         {
@@ -37,12 +39,12 @@ namespace TextureEditor.ViewModels
             public void ShowTextureDetailsInfo() => ViewModel.ShowTextureDetailsInfo();
         }
 
-        public static void CreateWindow(string imagePath, PackFileService packFileService)
+        public static void CreateWindow(string imagePath, PackFileService packFileService, EventHub eventHub)
         {
             TexturePreviewViewModel viewModel = new TexturePreviewViewModel();
             viewModel.ImagePath.Value = imagePath;
 
-            using (var controller = new TexturePreviewController(imagePath, viewModel, packFileService))
+            using (var controller = new TexturePreviewController(imagePath, viewModel, packFileService, eventHub))
             {
                 var containingWindow = new ControllerHostWindow(false, ResizeMode.CanResize);
                 containingWindow.Title = "Texture Preview Window";
@@ -51,13 +53,14 @@ namespace TextureEditor.ViewModels
             }
         }
 
-        public TexturePreviewController(string imagePath, TexturePreviewViewModel viewModel, PackFileService packFileService)
+        public TexturePreviewController(string imagePath, TexturePreviewViewModel viewModel, PackFileService packFileService, EventHub eventHub)
         {
             _imagePath = imagePath;
             _viewModel = viewModel;
             _packFileService = packFileService;
+            _eventHub = eventHub;
 
-            _scene = new GameWorld(null, null);
+            _scene = new GameWorld(_eventHub);
             _scene.Components.Add(new ResourceLibary(_scene, packFileService));
             _scene.ForceCreate();
 

--- a/Shared/GameFiles/AnimationPack/AnimationSlotType.cs
+++ b/Shared/GameFiles/AnimationPack/AnimationSlotType.cs
@@ -2,6 +2,7 @@
 using System.Text;
 using Shared.Core.PackFiles;
 using Shared.Core.Services;
+using Shared.EmbeddedResources;
 
 namespace Shared.GameFormats.AnimationPack
 {
@@ -40,23 +41,23 @@ namespace Shared.GameFormats.AnimationPack
             switch (game)
             {
                 case GameTypeEnum.Warhammer2:
-                    Load("CommonControls.Resources.AnimationSlots.Warhammer2AnimationSlots.txt");
+                    Load("Resources.AnimationSlots.Warhammer2AnimationSlots.txt");
                     break;
 
                 case GameTypeEnum.Warhammer3:
-                    Load("CommonControls.Resources.AnimationSlots.Warhammer3AnimationSlots_dlc24.txt");
+                    Load("Resources.AnimationSlots.Warhammer3AnimationSlots_dlc24.txt");
                     break;
 
                 case GameTypeEnum.Troy:
-                    Load("CommonControls.Resources.AnimationSlots.TroyAnimationSlots.txt");
+                    Load("Resources.AnimationSlots.TroyAnimationSlots.txt");
                     break;
 
                 case GameTypeEnum.ThreeKingdoms:
-                    Load("CommonControls.Resources.AnimationSlots.3kAnimationSlots.txt");
+                    Load("Resources.AnimationSlots.3kAnimationSlots.txt");
                     break;
 
                 default:
-                    Load("CommonControls.Resources.AnimationSlots.Warhammer2AnimationSlots.txt");
+                    Load("Resources.AnimationSlots.Warhammer2AnimationSlots.txt");
                     break;
             }
         }
@@ -84,13 +85,10 @@ namespace Shared.GameFormats.AnimationPack
         void Load(string resourcePath)
         {
             Values = new List<AnimationSlotType>();
-            using var stream = Assembly.GetExecutingAssembly().GetManifestResourceStream(resourcePath);
-            using (var reader = new StreamReader(stream))
-            {
-                var result = reader.ReadToEnd().Split(Environment.NewLine.ToCharArray(), StringSplitOptions.RemoveEmptyEntries);
-                for (var i = 0; i < result.Length; i++)
-                    Values.Add(new AnimationSlotType(i, result[i].Trim()));
-            }
+            var strings = ResourceLoader.LoadStringArray(resourcePath);
+            for (var i = 0; i < strings.Length; i++)
+                Values.Add(new AnimationSlotType(i, strings[i].Trim()));
+            
         }
 
         public void ExportAnimationDebugList(PackFileService pfs, string outputName)

--- a/Shared/GameFiles/Shared.GameFormats.csproj
+++ b/Shared/GameFiles/Shared.GameFormats.csproj
@@ -7,6 +7,7 @@
     </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\EmbeddedResources\Shared.EmbeddedResources.csproj" />
     <ProjectReference Include="..\SharedCore\Shared.Core.csproj" />
   </ItemGroup>
 

--- a/Shared/SharedCore/ErrorHandling/ErrorList.cs
+++ b/Shared/SharedCore/ErrorHandling/ErrorList.cs
@@ -9,6 +9,8 @@ namespace Shared.Core.ErrorHandling
         public string ItemName { get; set; }
         public string Description { get; set; }
         public bool IsError { get; set; } = false;
+
+        public bool IsWarning { get; set; } = false;
     }
 
     public class ErrorList
@@ -26,7 +28,7 @@ namespace Shared.Core.ErrorHandling
 
         public ErrorListDataItem Warning(string itemName, string description)
         {
-            var item = new ErrorListDataItem() { ErrorType = "Warning", ItemName = itemName, Description = description, IsError = true };
+            var item = new ErrorListDataItem() { ErrorType = "Warning", ItemName = itemName, Description = description, IsWarning = true };
             Errors.Add(item);
             return item;
         }

--- a/Shared/SharedUI/BaseDialogs/ErrorListDialog/ErrorListView.xaml
+++ b/Shared/SharedUI/BaseDialogs/ErrorListDialog/ErrorListView.xaml
@@ -13,6 +13,9 @@
                         <DataTrigger Binding="{Binding IsError}" Value="true">
                             <Setter Property="Background" Value="OrangeRed" />
                         </DataTrigger>
+                        <DataTrigger Binding="{Binding IsWarning}" Value="true">
+                            <Setter Property="Background" Value="#A98304" />
+                        </DataTrigger>
                     </Style.Triggers>
                 </Style>
             </ListView.Resources>


### PR DESCRIPTION
Removed the old resource loader and changed them to use the new resource loader to load animation slots.txt

Implemented validation check for "cavalry" animations 

- Ensure that the animation time of mount and rider is exact (or close to within margin 0.000001)
- Ensure that the animation length of mount and rider is exact 
- Ensure that the version for both mount and rider is the same
- Ensure that any animation version difference in the splice for persistence (or in the current slot) matches with the animation itself

Also implemented yellow for warning in error list dialog


![image](https://github.com/donkeyProgramming/TheAssetEditor/assets/24313753/3f15b257-5b16-486d-9188-f9d487759b8f)
