### PR TITLE
Fix missing name for models when loading some rmv2 files for Pharao  #137

### DIFF
--- a/GameWorld/View3D/SceneNodes/Rmv2MeshNode.cs
+++ b/GameWorld/View3D/SceneNodes/Rmv2MeshNode.cs
@@ -69,7 +69,7 @@ namespace GameWorld.Core.SceneNodes
         private Rmv2MeshNode()
         { }
 
-        public Rmv2MeshNode(RmvCommonHeader commonHeader, MeshObject meshObject, IMaterial material, AnimationPlayer animationPlayer, RenderEngineComponent renderEngineComponent, PbrShader shader = null)
+        public Rmv2MeshNode(RmvCommonHeader commonHeader, MeshObject meshObject, IMaterial material, AnimationPlayer animationPlayer, RenderEngineComponent renderEngineComponent, PbrShader shader = null )
         {
             CommonHeader = commonHeader;
             Material = material;

--- a/GameWorld/View3D/SceneNodes/Rmv2ModelNodeLoader.cs
+++ b/GameWorld/View3D/SceneNodes/Rmv2ModelNodeLoader.cs
@@ -46,6 +46,22 @@ namespace GameWorld.Core.SceneNodes
                 {
                     var geometry = MeshBuilderService.BuildMeshFromRmvModel(model.ModelList[lodIndex][modelIndex], model.Header.SkeletonName, _contextFactory.Create());
                     var rmvModel = model.ModelList[lodIndex][modelIndex];
+
+                    //This if statement is for Pharaoh Total War, the base game models do not have a model name by default so I am grabbing it
+                    //from the model file path.
+                    if (rmvModel.Material.ModelName == "")
+                    {
+                        string[] parts = modelFullPath.Split('\\');
+                        if (parts.Length >= 2)
+                        {
+                            rmvModel.Material.ModelName = parts[parts.Length - 2];
+                        }
+                        else
+                        {
+                            rmvModel.Material.ModelName = parts[0];
+                        }
+                    }
+
                     var node = new Rmv2MeshNode(rmvModel.CommonHeader, geometry, rmvModel.Material, animationPlayer, _renderEngineComponent);
                     node.Initialize(_resourceLibrary);
                     node.OriginalFilePath = modelFullPath;

--- a/GameWorld/View3D/SceneNodes/Rmv2ModelNodeLoader.cs
+++ b/GameWorld/View3D/SceneNodes/Rmv2ModelNodeLoader.cs
@@ -9,6 +9,7 @@ using Shared.Core.PackFiles;
 using Shared.Core.Services;
 using Shared.GameFormats.RigidModel;
 using System;
+using System.IO;
 
 namespace GameWorld.Core.SceneNodes
 {
@@ -49,17 +50,9 @@ namespace GameWorld.Core.SceneNodes
 
                     //This if statement is for Pharaoh Total War, the base game models do not have a model name by default so I am grabbing it
                     //from the model file path.
-                    if (rmvModel.Material.ModelName == "")
+                    if (String.IsNullOrWhiteSpace(rmvModel.Material.ModelName))
                     {
-                        string[] parts = modelFullPath.Split('\\');
-                        if (parts.Length >= 2)
-                        {
-                            rmvModel.Material.ModelName = parts[parts.Length - 2];
-                        }
-                        else
-                        {
-                            rmvModel.Material.ModelName = parts[0];
-                        }
+                        rmvModel.Material.ModelName = Path.GetFileNameWithoutExtension(modelFullPath);
                     }
 
                     var node = new Rmv2MeshNode(rmvModel.CommonHeader, geometry, rmvModel.Material, animationPlayer, _renderEngineComponent);

--- a/GameWorld/View3D/Services/SceneSaving/Material/Strategies/WsModelGeneratorService.cs
+++ b/GameWorld/View3D/Services/SceneSaving/Material/Strategies/WsModelGeneratorService.cs
@@ -108,17 +108,9 @@ namespace GameWorld.Core.Services.SceneSaving.Material.Strategies
                 var modelFullPath = mesh.OriginalFilePath;
                 //if mesh name is blank, grab a mesh name from the file path, so far the only
                 //total war with this issue appears to be Pharaoh.
-                if (fileName == "")
+                if (String.IsNullOrWhiteSpace(fileName))
                 {
-                    string[] parts = modelFullPath.Split('\\');
-                    if (parts.Length >= 2)
-                    {
-                        fileName = parts[parts.Length - 2];
-                    }
-                    else
-                    {
-                        fileName = parts[0];
-                    }
+                    modelFullPath = Path.GetFileNameWithoutExtension(fileName);
                 }
 
                 for (var index = 0; index < 1024; index++)

--- a/GameWorld/View3D/Services/SceneSaving/Material/Strategies/WsModelGeneratorService.cs
+++ b/GameWorld/View3D/Services/SceneSaving/Material/Strategies/WsModelGeneratorService.cs
@@ -105,6 +105,22 @@ namespace GameWorld.Core.Services.SceneSaving.Material.Strategies
             foreach (var mesh in meshes)
             {
                 var fileName = mesh.Name;
+                var modelFullPath = mesh.OriginalFilePath;
+                //if mesh name is blank, grab a mesh name from the file path, so far the only
+                //total war with this issue appears to be Pharaoh.
+                if (fileName == "")
+                {
+                    string[] parts = modelFullPath.Split('\\');
+                    if (parts.Length >= 2)
+                    {
+                        fileName = parts[parts.Length - 2];
+                    }
+                    else
+                    {
+                        fileName = parts[0];
+                    }
+                }
+
                 for (var index = 0; index < 1024; index++)
                 {
                     var name = index == 0 ? fileName : string.Format("{0}_{1}", fileName, index);


### PR DESCRIPTION
Object names now populate properly, this results in proper wsModel generation.