### PR TITLE
Closes #141

### DIFF
--- a/Shared/GameFiles/WsModel/WsModelMaterialFile.cs
+++ b/Shared/GameFiles/WsModel/WsModelMaterialFile.cs
@@ -37,6 +37,10 @@ namespace Shared.GameFormats.WsModel
                     VertexType = UiVertexFormat.Cinematic;
                 else if (Name.Contains("weighted2", StringComparison.InvariantCultureIgnoreCase))
                     VertexType = UiVertexFormat.Weighted;
+                else if (Name.Contains("weighted_standard_4", StringComparison.InvariantCultureIgnoreCase))
+                    VertexType = UiVertexFormat.Cinematic;
+                else if (Name.Contains("weighted_standard_2", StringComparison.InvariantCultureIgnoreCase))
+                    VertexType = UiVertexFormat.Weighted;
                 else
                     VertexType = UiVertexFormat.Static;
             }


### PR DESCRIPTION
This fixes the issues I listed in issue 141. Such as the material file creation naming and the shader naming for Pharaoh Total War specifically. The material file generation issue had some misnaming on the file name, as well as the shader being specified as one from other total war games.