### PR TITLE
Closes #124

### DIFF
--- a/Shared/SharedUI/BaseDialogs/PackFileBrowser/ContextMenuHandler.cs
+++ b/Shared/SharedUI/BaseDialogs/PackFileBrowser/ContextMenuHandler.cs
@@ -175,23 +175,7 @@ namespace Shared.Ui.BaseDialogs.PackFileBrowser
 
         void DuplicateNode()
         {
-            var fileName = Path.GetFileNameWithoutExtension(_selectedNode.Name);
-            var extention = Path.GetExtension(_selectedNode.Name);
-            if (Path.GetExtension(fileName) != null)
-            {
-                var extraExtension = Path.GetExtension(fileName);
-                extention = extraExtension + extention;
-                fileName = Path.GetFileNameWithoutExtension(fileName);
-            }
-            var newName = fileName + "_copy" + extention;
-
-            var bytes = _selectedNode.Item.DataSource.ReadData();
-            var packFile = new PackFile(newName, new MemorySource(bytes));
-
-            var parentPath = _selectedNode.GetFullPath();
-            var path = Path.GetDirectoryName(parentPath);
-
-            _packFileService.AddFileToPack(_selectedNode.FileOwner, path, packFile);
+            _uiCommandFactory.Create<DuplicateCommand>().Execute(_selectedNode.Item);
         }
 
         void CreateFolder()

--- a/Shared/SharedUI/BaseDialogs/PackFileBrowser/ContextMenuHandler.cs
+++ b/Shared/SharedUI/BaseDialogs/PackFileBrowser/ContextMenuHandler.cs
@@ -177,6 +177,12 @@ namespace Shared.Ui.BaseDialogs.PackFileBrowser
         {
             var fileName = Path.GetFileNameWithoutExtension(_selectedNode.Name);
             var extention = Path.GetExtension(_selectedNode.Name);
+            if (Path.GetExtension(fileName) != null)
+            {
+                var extraExtension = Path.GetExtension(fileName);
+                extention = extraExtension + extention;
+                fileName = Path.GetFileNameWithoutExtension(fileName);
+            }
             var newName = fileName + "_copy" + extention;
 
             var bytes = _selectedNode.Item.DataSource.ReadData();

--- a/Shared/SharedUI/DependencyInjectionContainer.cs
+++ b/Shared/SharedUI/DependencyInjectionContainer.cs
@@ -23,6 +23,7 @@ namespace Shared.Ui
         public override void Register(IServiceCollection services)
         {
             services.AddTransient<ImportAssetCommand>();
+            services.AddTransient<DuplicateCommand>();
 
             services.AddTransient<IWindowFactory, WindowFactory>();
             services.AddScoped<BoneMappingView>();

--- a/Shared/SharedUI/Events/UiCommands/DuplicateCommand.cs
+++ b/Shared/SharedUI/Events/UiCommands/DuplicateCommand.cs
@@ -1,0 +1,32 @@
+﻿using Shared.Core.Events;
+using Shared.Core.PackFiles;
+using Shared.Core.PackFiles.Models;
+using System.IO;
+
+namespace Shared.Ui.Events.UiCommands
+{
+    public class DuplicateCommand: IUiCommand
+    {
+        private readonly PackFileService _packFileService;
+
+        public DuplicateCommand(PackFileService packFileService) 
+        {
+            _packFileService = packFileService;
+        }
+
+        public void Execute(PackFile item)
+        {
+            var fileName = item.Name.Substring(0, item.Name.IndexOf("."));
+            var extention = item.Name.Substring(item.Name.IndexOf("."));
+
+            var newName = fileName + "_copy" + extention;
+            var bytes = item.DataSource.ReadData();
+            var packFile = new PackFile(newName, new MemorySource(bytes));
+            var parentPath = _packFileService.GetFullPath(item);
+            var packContainer = _packFileService.GetPackFileContainer(item);
+            var path = Path.GetDirectoryName(parentPath);
+
+            _packFileService.AddFileToPack(packContainer, path, packFile);
+        }
+    }
+}

--- a/Testing/E2EVerification/Shared/GameMock.cs
+++ b/Testing/E2EVerification/Shared/GameMock.cs
@@ -26,7 +26,7 @@ namespace E2EVerification.Shared
             // servies.AddService(typeof(GraphicsDevice), this);
             servies.AddService(typeof(IGraphicsDeviceService), test);
 
-            Content = new ContentManager(servies, "C:\\Users\\ole_k\\source\\repos\\TheAssetEditor\\GameWorld\\ContentProject\\BuiltContent");
+            Content = new ContentManager(servies, "C:\\Users\\Josh E\\source\\repos\\TheAssetEditor\\GameWorld\\ContentProject\\BuiltContent");
         }
 
         public T AddComponent<T>(T comp) where T : IGameComponent

--- a/Testing/E2EVerification/UIEvent_Tests.cs
+++ b/Testing/E2EVerification/UIEvent_Tests.cs
@@ -1,0 +1,28 @@
+﻿using E2EVerification.Shared;
+using Shared.Ui.Events.UiCommands;
+
+namespace E2EVerification
+{
+
+
+    internal class UIEvent_Tests
+    {
+        private readonly string _packFile = "C:\\Program Files (x86)\\Steam\\steamapps\\common\\Total War WARHAMMER III\\data\\meta_test_issue_124.pack";
+        private readonly string _anmMetaFile = @"animations\battle\humanoid01\halberd\attacks\hu1_noctilus_attack.anm.meta";
+
+        [SetUp]
+        public void Setup()
+        {
+        }
+        [Test]
+        public void DuplicateTest()
+        {
+            var runner = new AssetEditorTestRunner();
+            var pack = runner.LoadPackFile(_packFile);
+            var item = runner.PackFileService.FindFile(_anmMetaFile);
+
+            runner.CommandFactory.Create<DuplicateCommand>().Execute(item);
+            runner.PackFileService.FindFile("animations\\battle\\humanoid01\\halberd\\attacks\\hu1_noctilus_attack_copy.anm.meta");
+        }
+    }
+}


### PR DESCRIPTION
This solution should work for any file that has multiple extensions (no idea if there are any more, but decided to make it generic just in case). Tested by duplication multiple anm.meta files and checking that the values matched the originals.