### PR TITLE
Fixes for duplicate command test cases

### DIFF
--- a/Shared/SharedUI/Events/UiCommands/DuplicateFileCommand.cs
+++ b/Shared/SharedUI/Events/UiCommands/DuplicateFileCommand.cs
@@ -17,21 +17,16 @@ namespace Shared.Ui.Events.UiCommands
 
         public void Execute(PackFile item)
         {
-            try
+            var fileName = item.Name;
+            var extension = "";
+            if(Path.HasExtension(item.Name) == true)
             {
-                var fileName = item.Name.Substring(0, item.Name.IndexOf("."));
-                var extension = item.Name.Substring(item.Name.IndexOf("."));
-                var newName = fileName + "_copy" + extension;
-
-                readAndSave(fileName, newName, item);
+                var index = item.Name.IndexOf('.');
+                fileName = item.Name.Substring(0, index);
+                extension = item.Name.Substring(index);
             }
-            catch (ArgumentOutOfRangeException)
-            {
-                var fileName = item.Name;
-                var newName = fileName + "_copy";
-
-                readAndSave(fileName, newName, item);
-            }
+            var newName = fileName + "_copy" + extension;
+            readAndSave(fileName, newName, item);
         }
 
         public void readAndSave(string filename, string newName, PackFile item)

--- a/Shared/SharedUI/Events/UiCommands/DuplicateFileCommand.cs
+++ b/Shared/SharedUI/Events/UiCommands/DuplicateFileCommand.cs
@@ -1,6 +1,7 @@
 ﻿using Shared.Core.Events;
 using Shared.Core.PackFiles;
 using Shared.Core.PackFiles.Models;
+using System;
 using System.IO;
 
 namespace Shared.Ui.Events.UiCommands
@@ -16,17 +17,34 @@ namespace Shared.Ui.Events.UiCommands
 
         public void Execute(PackFile item)
         {
-            var fileName = item.Name.Substring(0, item.Name.IndexOf("."));
-            var extension = item.Name.Substring(item.Name.IndexOf("."));
+            try
+            {
+                var fileName = item.Name.Substring(0, item.Name.IndexOf("."));
+                var extension = item.Name.Substring(item.Name.IndexOf("."));
+                var newName = fileName + "_copy" + extension;
 
-            var newName = fileName + "_copy" + extension;
+                readAndSave(fileName, newName, item);
+            }
+            catch (ArgumentOutOfRangeException)
+            {
+                var fileName = item.Name;
+                var newName = fileName + "_copy";
+
+                readAndSave(fileName, newName, item);
+            }
+        }
+
+        public void readAndSave(string filename, string newName, PackFile item)
+        {
             var bytes = item.DataSource.ReadData();
             var packFile = new PackFile(newName, new MemorySource(bytes));
             var parentPath = _packFileService.GetFullPath(item);
             var packContainer = _packFileService.GetPackFileContainer(item);
             var path = Path.GetDirectoryName(parentPath);
 
-            _packFileService.AddFileToPack(packContainer, path, packFile);
+            _packFileService.AddFileToPack(_packFileService.GetEditablePack(), path, packFile);
         }
+
+
     }
 }

--- a/Shared/SharedUI/Events/UiCommands/DuplicateFileCommand.cs
+++ b/Shared/SharedUI/Events/UiCommands/DuplicateFileCommand.cs
@@ -26,10 +26,10 @@ namespace Shared.Ui.Events.UiCommands
                 extension = item.Name.Substring(index);
             }
             var newName = fileName + "_copy" + extension;
-            ReadAndSave(fileName, newName, item);
+            ReadAndSave(newName, item);
         }
 
-        private void ReadAndSave(string filename, string newName, PackFile item)
+        private void ReadAndSave(string newName, PackFile item)
         {
             var bytes = item.DataSource.ReadData();
             var packFile = new PackFile(newName, new MemorySource(bytes));

--- a/Shared/SharedUI/Events/UiCommands/DuplicateFileCommand.cs
+++ b/Shared/SharedUI/Events/UiCommands/DuplicateFileCommand.cs
@@ -26,20 +26,18 @@ namespace Shared.Ui.Events.UiCommands
                 extension = item.Name.Substring(index);
             }
             var newName = fileName + "_copy" + extension;
-            readAndSave(fileName, newName, item);
+            ReadAndSave(fileName, newName, item);
         }
 
-        public void readAndSave(string filename, string newName, PackFile item)
+        private void ReadAndSave(string filename, string newName, PackFile item)
         {
             var bytes = item.DataSource.ReadData();
             var packFile = new PackFile(newName, new MemorySource(bytes));
             var parentPath = _packFileService.GetFullPath(item);
-            var packContainer = _packFileService.GetPackFileContainer(item);
             var path = Path.GetDirectoryName(parentPath);
+            var editablePack = _packFileService.GetEditablePack();
 
-            _packFileService.AddFileToPack(_packFileService.GetEditablePack(), path, packFile);
+            _packFileService.AddFileToPack(editablePack, path, packFile);
         }
-
-
     }
 }


### PR DESCRIPTION
Fixed an issue with the packfile saving, also fixed an issue with a ArgumentOutOfBounds exception when substring would be run on a file without extension. I chose to make an extra helper method to clean up what is occurring in the execute function as well.