### PR TITLE
Feat: Added per-model faction coloring and tinting, simple UI

### DIFF
--- a/GameWorld/ContentProject/Content/Shaders/Pbr/Capabilites/Tint.hlsli
+++ b/GameWorld/ContentProject/Content/Shaders/Pbr/Capabilites/Tint.hlsli
@@ -1,13 +1,13 @@
 #include "../helpers/mathfunctions.hlsli"
 
 // Input parameters 
-bool CapabilityFlag_ApplyTinting = true; // D3D 11 HLSL global non-static consts are = 0, init values are not used
-bool Tint_UseFactionColours = false;
-bool Tint_UseTinting = true;
-float3 Tint_FactionsColours[3] = { float3(1, 0, 0), float3(0, 1, 0), float3(0, 0, 1) };
-float4 Tint_Mask = float4(0, 0, 0, 0);
-float3 Tint_TintColours[3] = { { 0.59, 0.56, 0.48 }, { 0.33, 0.29, 0.43 }, { 0.38, 0.48, 0.36 } };
-float Tint_TintVariation = 0;
+bool CapabilityFlag_ApplyTinting;
+bool Tint_UseFactionColours;
+bool Tint_UseTinting;
+float3 Tint_FactionsColours[3];
+float3 Tint_TintColours[3];
+float4 Tint_Mask;
+float Tint_TintVariation;
 
 float3 ApplyTintAndFactionColours(float3 textureDiffuse, float4 maskValue)
 {        
@@ -17,18 +17,17 @@ float3 ApplyTintAndFactionColours(float3 textureDiffuse, float4 maskValue)
     float3 diffuseResult = textureDiffuse;
     if (Tint_UseFactionColours)
     {
-        diffuseResult = lerp(diffuseResult.rgb, diffuseResult.rgb * (Tint_FactionsColours[0]), maskValue.r);
-        diffuseResult = lerp(diffuseResult.rgb, diffuseResult.rgb * (Tint_FactionsColours[1]), maskValue.g);
-        diffuseResult = lerp(diffuseResult.rgb, diffuseResult.rgb * (Tint_FactionsColours[2]), maskValue.b);
-    }
+        diffuseResult = lerp(diffuseResult.rgb, diffuseResult.rgb * _linear(Tint_FactionsColours[0]), maskValue.r);
+        diffuseResult = lerp(diffuseResult.rgb, diffuseResult.rgb * _linear(Tint_FactionsColours[1]), maskValue.g);
+        diffuseResult = lerp(diffuseResult.rgb, diffuseResult.rgb * _linear(Tint_FactionsColours[2]), maskValue.b);
+    }    
     
-    // mix tinting into the result?
-    if (Tint_UseTinting)    
-    {            
+    if (Tint_UseTinting) // allow tinting of faction colored pixel
+    {
         diffuseResult = lerp(diffuseResult.rgb, diffuseResult.rgb * _linear(Tint_TintColours[0]), maskValue.r);
         diffuseResult = lerp(diffuseResult.rgb, diffuseResult.rgb * _linear(Tint_TintColours[1]), maskValue.g);
-        diffuseResult = lerp(diffuseResult.rgb, diffuseResult.rgb * _linear(Tint_TintColours[2]), maskValue.b);        
-    }       
+        diffuseResult = lerp(diffuseResult.rgb, diffuseResult.rgb * _linear(Tint_TintColours[2]), maskValue.b);
+    }
     
     return diffuseResult;
 }

--- a/GameWorld/View3D/Rendering/Materials/Capabilities/TintCapability.cs
+++ b/GameWorld/View3D/Rendering/Materials/Capabilities/TintCapability.cs
@@ -15,16 +15,26 @@ namespace GameWorld.Core.Rendering.Materials.Capabilities
         public Vector4 DiffuseTintMask { get; set; } = Vector4.Zero;
         public Vector3 DiffuseTintColour { get; set; } = Vector3.Zero;
         public float DiffuseTintVariation { get; set; }
-
         public bool UseFactionColours { get; set; } = true;
+        public bool UseTinting { get; set; } = false;
         public Vector4 Faction3Mask { get; set; } = Vector4.Zero;
         public float Faction1_TintVariation { get; set; } = 0;  //Replace as vector3?
         public float Faction2_TintVariation { get; set; } = 0;
         public float Faction3_TintVariation { get; set; } = 0;
         public Vector3[] FactionColours { get; set; } = [new Vector3(1, 0, 0), new Vector3(0, 1, 0), new Vector3(0, 0, 1)];
+        public Vector3[] TintColours { get; set; } = [new Vector3(0.7f, 0.7f, 0.6f), new Vector3(0.6f, 0.6f, 0.7f), new Vector3(0.7f, 0.6f, 0.6f)];
 
         public void Apply(Effect effect, ResourceLibrary resourceLibrary)
         {
+
+            effect.Parameters["CapabilityFlag_ApplyTinting"].SetValue(ApplyCapability);
+
+            effect.Parameters["Tint_UseFactionColours"].SetValue(UseFactionColours);
+            effect.Parameters["Tint_FactionsColours"].SetValue(FactionColours);
+
+            effect.Parameters["Tint_UseTinting"].SetValue(UseTinting);
+            effect.Parameters["Tint_TintColours"].SetValue(TintColours);
+            effect.Parameters["Tint_TintColours"].SetValue(TintColours);
         }
 
         public ICapability Clone()
@@ -57,12 +67,12 @@ namespace GameWorld.Core.Rendering.Materials.Capabilities
 
         public void SerializeToRmvMaterial(IRmvMaterial rmvMaterial)
         {
-         
+
         }
 
         public void SerializeToWsModel(WsMaterialTemplateEditor templateHandler)
         {
-         
+
         }
     }
 }

--- a/GameWorld/View3D/Rendering/Materials/Shaders/CapabilityMaterial.cs
+++ b/GameWorld/View3D/Rendering/Materials/Shaders/CapabilityMaterial.cs
@@ -77,6 +77,11 @@ namespace GameWorld.Core.Rendering.Materials.Shaders
         {
             GetCapability<CommonShaderParametersCapability>().Assign(commonShaderParameters, modelMatrix);
 
+            var tintCapability = TryGetCapability<TintCapability>();
+
+            if (tintCapability != null)
+                tintCapability.FactionColours = commonShaderParameters.FactionColours;
+
             var effect = GetEffect();
             OnApply(effect);
 
@@ -108,7 +113,7 @@ namespace GameWorld.Core.Rendering.Materials.Shaders
                 return (false, $"Different material types {Type} vs {other.Type}");
 
             for (var i = 0; i < Capabilities.Length; i++)
-            { 
+            {
                 var ownCap = Capabilities[i];
                 var otherCap = other.Capabilities[i];
                 if (ownCap.GetType() != otherCap.GetType())

--- a/GameWorld/View3D/Rendering/Materials/Shaders/MetalRough/DefaultMaterial.cs
+++ b/GameWorld/View3D/Rendering/Materials/Shaders/MetalRough/DefaultMaterial.cs
@@ -16,6 +16,7 @@ namespace GameWorld.Core.Rendering.Materials.Shaders.MetalRough
                     new MetalRoughCapability(),
                     new AnimationCapability(),
                     new BloodCapability(),
+                    new TintCapability(),
                 ];
 
             _renderingTechniqueMap[RenderingTechnique.Normal] = "BasicColorDrawing";

--- a/GameWorld/View3D/Rendering/Materials/Shaders/SpecGloss/DefaultMaterial.cs
+++ b/GameWorld/View3D/Rendering/Materials/Shaders/SpecGloss/DefaultMaterial.cs
@@ -14,6 +14,7 @@ namespace GameWorld.Core.Rendering.Materials.Shaders.SpecGloss
                 new CommonShaderParametersCapability(),
                 new SpecGlossCapability(),
                 new AnimationCapability(),
+                new TintCapability(),
             ];
 
             _renderingTechniqueMap[RenderingTechnique.Normal] = "BasicColorDrawing";


### PR DESCRIPTION
# Add: Faction Coloring And Tinting

![image](https://github.com/user-attachments/assets/661e3d02-b606-42e7-b2aa-a1a6866fb7c1)

Faction colored is "hardcoded" = enabled, which is fine, as meshes without faction color has no mask tex -> mask = {0,0,0,0] = faction coloring with not affect mesh.