### PR TITLE
Fix: Issues: Textures saving, and vertex weights

### DIFF
--- a/Editors/Editors.ImportExport/Exporting/Exporters/DdsToMaterialPng/DdsToMaterialPngExporter.cs
+++ b/Editors/Editors.ImportExport/Exporting/Exporters/DdsToMaterialPng/DdsToMaterialPngExporter.cs
@@ -24,15 +24,14 @@ namespace Editors.ImportExport.Exporting.Exporters.DdsToMaterialPng
             var fileDirectory = outputPath + "/" + fileName + ".png";
             var bytes = packFile.DataSource.ReadData();
             var imgBytes = TextureHelper.ConvertDdsToPng(bytes);
- 
+
             if (convertToBlenderFormat)
             {
-                ConvertToBlenderFormat(imgBytes, outputPath, fileDirectory);
+                imgBytes = ConvertToBlenderFormat(imgBytes, outputPath, fileDirectory);
             }
-            else
-            {
-                DoNotConvertExport(imgBytes, outputPath, fileDirectory);
-            }
+
+            _imageSaveHandler.Save(imgBytes, fileDirectory);
+
             return fileDirectory;
         }
 
@@ -45,7 +44,7 @@ namespace Editors.ImportExport.Exporting.Exporters.DdsToMaterialPng
             return ExportSupportEnum.NotSupported;
         }
 
-        void ConvertToBlenderFormat(byte[] imgBytes, string outputPath, string fileDirectory)
+        byte[] ConvertToBlenderFormat(byte[] imgBytes, string outputPath, string fileDirectory)
         {
             var ms = new MemoryStream(imgBytes);
 
@@ -64,8 +63,12 @@ namespace Editors.ImportExport.Exporting.Exporters.DdsToMaterialPng
                         bitmap.SetPixel(x, y, newColor);
                     }
                 }
-                //_imageSaveHandler.Save(bitmap, fileDirectory);
-                throw new NotImplementedException();
+
+                // get raw PNG bytes
+                using var b = new MemoryStream();
+                bitmap.Save(b, System.Drawing.Imaging.ImageFormat.Png);
+
+                return b.ToArray();
             }
         }
 

--- a/Editors/Editors.ImportExport/Exporting/Exporters/DdsToNormalPng/DdsToNormalPngExporter.cs
+++ b/Editors/Editors.ImportExport/Exporting/Exporters/DdsToNormalPng/DdsToNormalPngExporter.cs
@@ -36,20 +36,19 @@ namespace Editors.ImportExport.Exporting.Exporters.DdsToNormalPng
             var imgBytes = TextureHelper.ConvertDdsToPng(bytes);
            
             if (convertToBlueNormalMap)
-                ConvertToBlueNormalMap(imgBytes, fullFilePath);
+                imgBytes = ConvertToBlueNormalMap(imgBytes, fullFilePath);
 
             _imageSaveHandler.Save(imgBytes, fullFilePath);
             return fullFilePath;
         }
 
 
-        private void ConvertToBlueNormalMap(byte[] imgBytes, string fileDirectory)
+        private byte[] ConvertToBlueNormalMap(byte[] imgBytes, string fileDirectory)
         {
-            var ms = new MemoryStream(imgBytes);
+            var inMs = new MemoryStream(imgBytes);
+            using Image inImg = Image.FromStream(inMs);
 
-            using Image img = Image.FromStream(ms);
-
-            using Bitmap bitmap = new Bitmap(img);
+            using Bitmap bitmap = new Bitmap(inImg);
             {
                 for (int x = 0; x < bitmap.Width; x++)
                 {
@@ -95,8 +94,12 @@ namespace Editors.ImportExport.Exporting.Exporters.DdsToNormalPng
                         bitmap.SetPixel(x, y, newColor);
                     }
                 }
-                throw new NotImplementedException();
-                //_imageSaveHandler.Save(bitmap, fileDirectory);
+
+                // get raw PNG bytes
+                using var b = new MemoryStream();
+                bitmap.Save(b, System.Drawing.Imaging.ImageFormat.Png);
+
+                return b.ToArray();
             }
         }
 

--- a/Editors/Editors.ImportExport/Exporting/Exporters/RmvToGltf/Helpers/GltfMeshBuilder.cs
+++ b/Editors/Editors.ImportExport/Exporting/Exporters/RmvToGltf/Helpers/GltfMeshBuilder.cs
@@ -74,11 +74,11 @@ namespace Editors.ImportExport.Exporting.Exporters.RmvToGltf.Helpers
 
                 if (hasSkeleton)
                 {
-                    SetVertexInfluences(vertex, glTfvertex);
+                    glTfvertex = SetVertexInfluences(vertex, glTfvertex);
                 }
                 else
                 {
-                    glTfvertex.Skinning.SetBindings((0, 1));
+                    glTfvertex.Skinning.SetBindings((0, 1), (0, 0), (0, 0), (0, 0));
                 }
                 vertexList.Add(glTfvertex);
             }
@@ -107,7 +107,7 @@ namespace Editors.ImportExport.Exporting.Exporters.RmvToGltf.Helpers
         }
 
 
-        void SetVertexInfluences(CommonVertex vertex, VertexBuilder<VertexPositionNormalTangent, VertexTexture1, VertexJoints4> glTfvertex)
+        VertexBuilder<VertexPositionNormalTangent, VertexTexture1, VertexJoints4> SetVertexInfluences(CommonVertex vertex, VertexBuilder<VertexPositionNormalTangent, VertexTexture1, VertexJoints4> glTfvertex)
         {
             if (vertex.WeightCount == 2)
             {
@@ -130,6 +130,8 @@ namespace Editors.ImportExport.Exporting.Exporters.RmvToGltf.Helpers
 
                 glTfvertex.Skinning.SetBindings(rigging);
             }
+
+            return glTfvertex;
         }
 
         List<MaterialBuilderTextureInput> ExtractTextures(RmvModel model)
@@ -163,8 +165,8 @@ namespace Editors.ImportExport.Exporting.Exporters.RmvToGltf.Helpers
             var baseColourTexture = textures.FirstOrDefault(t => t.Type == TextureType.BaseColour);
             if (baseColourTexture.Path != null)
             {
-                //  systemPath = _ddsToPngExporter.GenericExportNoConversion(settings.OutputPath, baseColourTexture);
-                //  material.WithChannelImage(KnownChannel.BaseColor, systemPath);
+                var systemPath = _ddsToMaterialPngExporter.Export(baseColourTexture.Path, settings.OutputPath, false); // TODO: write a separate class for base colour
+                material.WithChannelImage(KnownChannel.BaseColor, systemPath);
             }
 
             return material;


### PR DESCRIPTION
### Issues fixed
- DDS to PNG Texture saving to disk (for Rmv2ToGltf) was disabled, with NotImpl throws
- Gltf vertex weights/joint indices were not being set, were all 0
