### PR TITLE
Fixes for Gltf Export Bugs Reported  by Users

### DIFF
--- a/AssetEditor/spellingexclusions.dic
+++ b/AssetEditor/spellingexclusions.dic
@@ -22,10 +22,10 @@
 ﻿anim
 ﻿Lods
 ﻿Gltf
-﻿glft
+﻿gltf
 ﻿color
 ﻿Gltf
-﻿glft
+﻿gltf
 ﻿callback
 ﻿Callback
 ﻿Callback

--- a/Editors/Editors.ImportExport/Exporting/Exporters/DdsToMaterialPng/DdsToMaterialPngExporter.cs
+++ b/Editors/Editors.ImportExport/Exporting/Exporters/DdsToMaterialPng/DdsToMaterialPngExporter.cs
@@ -22,20 +22,27 @@ namespace Editors.ImportExport.Exporting.Exporters.DdsToMaterialPng
             var packFile = _pfs.FindFile(filePath);
             if (packFile == null)            
                 return "";
-            
+
             var fileName = Path.GetFileNameWithoutExtension(filePath);
-            var fileDirectory = outputPath + "/" + fileName + ".png";
+            var outDirectory = Path.GetDirectoryName(outputPath);
+            var outFilePath = outDirectory + "/" + fileName + ".png";
+
             var bytes = packFile.DataSource.ReadData();
+            if (bytes == null || !bytes.Any())
+                throw new Exception($"Could not read file data. bytes.Count = {bytes?.Length}");
+
             var imgBytes = TextureHelper.ConvertDdsToPng(bytes);
+            if (imgBytes == null || !imgBytes.Any())
+                throw new Exception($"image data invalid/empty. imgBytes.Count = {imgBytes?.Length}");
 
             if (convertToBlenderFormat)
             {
-                imgBytes = ConvertToBlenderFormat(imgBytes, outputPath, fileDirectory);
+                imgBytes = ConvertToBlenderFormat(imgBytes, outputPath, outFilePath);
             }
 
-            _imageSaveHandler.Save(imgBytes, fileDirectory);
+            _imageSaveHandler.Save(imgBytes, outFilePath);
 
-            return fileDirectory;
+            return outFilePath;
         }
 
         internal ExportSupportEnum CanExportFile(PackFile file)

--- a/Editors/Editors.ImportExport/Exporting/Exporters/DdsToMaterialPng/DdsToMaterialPngExporter.cs
+++ b/Editors/Editors.ImportExport/Exporting/Exporters/DdsToMaterialPng/DdsToMaterialPngExporter.cs
@@ -20,6 +20,9 @@ namespace Editors.ImportExport.Exporting.Exporters.DdsToMaterialPng
         public string Export(string filePath, string outputPath, bool convertToBlenderFormat)
         {
             var packFile = _pfs.FindFile(filePath);
+            if (packFile == null)            
+                return "";
+            
             var fileName = Path.GetFileNameWithoutExtension(filePath);
             var fileDirectory = outputPath + "/" + fileName + ".png";
             var bytes = packFile.DataSource.ReadData();

--- a/Editors/Editors.ImportExport/Exporting/Exporters/DdsToNormalPng/DdsToNormalPngExporter.cs
+++ b/Editors/Editors.ImportExport/Exporting/Exporters/DdsToNormalPng/DdsToNormalPngExporter.cs
@@ -12,6 +12,7 @@ namespace Editors.ImportExport.Exporting.Exporters.DdsToNormalPng
     {
         private readonly PackFileService _pfs;
         private readonly IImageSaveHandler _imageSaveHandler;
+
         public DdsToNormalPngExporter(PackFileService packFileService, IImageSaveHandler imageSaveHandler) 
         {
             _pfs = packFileService;
@@ -30,6 +31,9 @@ namespace Editors.ImportExport.Exporting.Exporters.DdsToNormalPng
         public string Export(string filePath, string outputPath, bool convertToBlueNormalMap)
         {
             var packFile = _pfs.FindFile(filePath);
+            if (packFile == null)
+                return "";
+
             var fileName = Path.GetFileNameWithoutExtension(filePath);
             var fullFilePath = outputPath + "/" + fileName + ".png";
             var bytes = packFile.DataSource.ReadData();

--- a/Editors/Editors.ImportExport/Exporting/Exporters/DdsToNormalPng/DdsToNormalPngExporter.cs
+++ b/Editors/Editors.ImportExport/Exporting/Exporters/DdsToNormalPng/DdsToNormalPngExporter.cs
@@ -35,10 +35,17 @@ namespace Editors.ImportExport.Exporting.Exporters.DdsToNormalPng
                 return "";
 
             var fileName = Path.GetFileNameWithoutExtension(filePath);
-            var fullFilePath = outputPath + "/" + fileName + ".png";
+            var outDirectory = Path.GetDirectoryName(outputPath);
+            var fullFilePath = outDirectory + "/" + fileName + ".png";
+
             var bytes = packFile.DataSource.ReadData();
+            if (bytes == null || !bytes.Any())
+                throw new Exception($"Could not read file data. bytes.Count = {bytes?.Length}");
+
             var imgBytes = TextureHelper.ConvertDdsToPng(bytes);
-           
+            if (imgBytes == null || !imgBytes.Any())
+                throw new Exception($"image data invalid/empty. imgBytes.Count = {imgBytes?.Length}");
+
             if (convertToBlueNormalMap)
                 imgBytes = ConvertToBlueNormalMap(imgBytes, fullFilePath);
 

--- a/Editors/Editors.ImportExport/Exporting/Exporters/RmvToGltf/Helpers/GltfMeshBuilder.cs
+++ b/Editors/Editors.ImportExport/Exporting/Exporters/RmvToGltf/Helpers/GltfMeshBuilder.cs
@@ -152,25 +152,27 @@ namespace Editors.ImportExport.Exporting.Exporters.RmvToGltf.Helpers
             if (normalMapTexture.Path != null)
             {
                 var systemPath = _ddsToNormalPngExporter.Export(normalMapTexture.Path, settings.OutputPath, settings.ConvertNormalTextureToBlue);
-                material.WithChannelImage(KnownChannel.Normal, systemPath);
+                if (systemPath.Any())
+                    material.WithChannelImage(KnownChannel.Normal, systemPath);
             }
 
             var materialTexture = textures.FirstOrDefault(t => t.Type == TextureType.MaterialMap);
             if (materialTexture.Path != null)
             {
                 var systemPath = _ddsToMaterialPngExporter.Export(materialTexture.Path, settings.OutputPath, settings.ConvertMaterialTextureToBlender);
-                material.WithChannelImage(KnownChannel.MetallicRoughness, systemPath);
+                if (systemPath.Any())
+                    material.WithChannelImage(KnownChannel.MetallicRoughness, systemPath);
             }
 
             var baseColourTexture = textures.FirstOrDefault(t => t.Type == TextureType.BaseColour);
             if (baseColourTexture.Path != null)
             {
                 var systemPath = _ddsToMaterialPngExporter.Export(baseColourTexture.Path, settings.OutputPath, false); // TODO: write a separate class for base colour
-                material.WithChannelImage(KnownChannel.BaseColor, systemPath);
+                if (systemPath.Any())
+                    material.WithChannelImage(KnownChannel.BaseColor, systemPath);
             }
 
             return material;
-
         }
     }
 }

--- a/Editors/Editors.ImportExport/Exporting/Exporters/RmvToGltf/RmvToGltfExporter.cs
+++ b/Editors/Editors.ImportExport/Exporting/Exporters/RmvToGltf/RmvToGltfExporter.cs
@@ -26,13 +26,11 @@ namespace Editors.ImportExport.Exporting.Exporters.RmvToGltf
     {
         private readonly PackFileService _packFileService;
         private readonly GltfMeshBuilder _gltfMeshBuilder;
-        private readonly GltfSkeletonCreator _gltfSkeletonCreator;
 
-        public RmvToGltfExporter(PackFileService packFileSerivce,  GltfMeshBuilder gltfMeshBuilder, GltfSkeletonCreator gltfSkeletonCreator)
+        public RmvToGltfExporter(PackFileService packFileSerivce,  GltfMeshBuilder gltfMeshBuilder)
         {
             _packFileService = packFileSerivce;
-            _gltfMeshBuilder = gltfMeshBuilder;
-            _gltfSkeletonCreator = gltfSkeletonCreator;
+            _gltfMeshBuilder = gltfMeshBuilder;            
         }
 
         internal ExportSupportEnum CanExportFile(PackFile file)
@@ -57,7 +55,7 @@ namespace Editors.ImportExport.Exporting.Exporters.RmvToGltf
             if (hasSkeleton)
             {
                 var animSkeletonFile = FetchAnimSkeleton(rmv2);
-                gltfSkeleton = _gltfSkeletonCreator.Create(outputScene, animSkeletonFile, doMirror);
+                gltfSkeleton = GltfSkeletonCreator.Create(outputScene, animSkeletonFile, doMirror);
 
                 if (settings.ExportAnimations && settings.InputAnimationFiles != null && settings.InputAnimationFiles.Any())
                     GenerateAnimations(settings, gltfSkeleton, outputScene, animSkeletonFile, doMirror);

--- a/Editors/Editors.ImportExport/Exporting/Exporters/RmvToGltf/RmvToGltfExporter.cs
+++ b/Editors/Editors.ImportExport/Exporting/Exporters/RmvToGltf/RmvToGltfExporter.cs
@@ -80,9 +80,8 @@ namespace Editors.ImportExport.Exporting.Exporters.RmvToGltf
                 else
                     scene.CreateNode(mesh.Name).WithMesh(mesh);
             }
-            outputScene.SaveGLTF(settings.OutputPath + Path.GetFileNameWithoutExtension(settings.InputModelFile.Name) + ".gltf");
+            outputScene.SaveGLTF(settings.OutputPath);
         }
-
 
         // MOve this into skeleton/animation builder
         void GenerateAnimations(RmvToGltfExporterSettings settings, ProcessedGltfSkeleton gltfSkeleton, ModelRoot outputScene, AnimationFile animSkeletonFile, bool doMirror)

--- a/Editors/Editors.ImportExport/Exporting/Presentation/ExportWindow.xaml
+++ b/Editors/Editors.ImportExport/Exporting/Presentation/ExportWindow.xaml
@@ -26,8 +26,8 @@
 
         <TextBlock Grid.Row="0" Grid.Column="0" Text="System Path" HorizontalAlignment="Left"/>
         <TextBlock Grid.Row="0" Grid.Column="1" Text=": "/>
-        <TextBox Grid.Row="0" Grid.Column="2" Text="{Binding SystemPath}" HorizontalContentAlignment="Right"/>
-        <Button Grid.Row="0" Grid.Column="3" Content="Browse" Command="{Binding BrowsePathCommand}"/>
+        <TextBox Grid.Row="0" Grid.Column="2" Text="{Binding SystemPath}" HorizontalContentAlignment="Right" IsReadOnly="True"/>
+        <Button Grid.Row="0" Grid.Column="3" Content="Browse" Command="{Binding BrowsePathCommandCommand}"/>
 
         <TextBlock Grid.Row="1" Grid.Column="0" Text="Create Import project   " HorizontalAlignment="Left"/>
         <TextBlock Grid.Row="1" Grid.Column="1" Text=": "/>

--- a/Editors/Editors.ImportExport/Exporting/Presentation/RmvToGltf/RmvToGltfExporterViewModel.cs
+++ b/Editors/Editors.ImportExport/Exporting/Presentation/RmvToGltf/RmvToGltfExporterViewModel.cs
@@ -12,7 +12,7 @@ namespace Editors.ImportExport.Exporting.Presentation.RmvToGltf
         private readonly RmvToGltfExporter _exporter;
 
         public string DisplayName => "Rmv_to_Gltf";
-        public string OutputExtension => ".glft";
+        public string OutputExtension => ".gltf";
 
         [ObservableProperty] bool _exportTextures = true;
         [ObservableProperty] bool _convertMaterialTextureToBlender = true;

--- a/Editors/Editors.ImportExport/Importing/Importers/GltfToRmv/GltfImporter.cs
+++ b/Editors/Editors.ImportExport/Importing/Importers/GltfToRmv/GltfImporter.cs
@@ -46,14 +46,5 @@ namespace Editors.ImportExport.Importing.Importers.GltfToRmv
 
             return importedFileName;
         }
-
-        private static void TESTING_SaveTestFileToDisk(GltfImporterSettings settings, byte[] bytes)
-        {
-            var docsFolder = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
-            var fileNameOnly = Path.GetFileNameWithoutExtension(settings.InputGltfFile);
-            var modelStream = File.Open($@"{docsFolder}\{fileNameOnly}.rigid_model_v2", FileMode.Create);
-            var binaryWriter = new BinaryWriter(modelStream);
-            binaryWriter.Write(bytes);
-        }
     }
 }


### PR DESCRIPTION
### Fixes for Exporter 

Users had some issues at the very first real world test of the export.

**Changes**
- SystemPath text box is read-only, browse button only way.
- Browse button was non-functional, fixes
- DDS file paths from RMV2, that are not found are skipped (proper paths are in WSMODEL/XMLMATERIAL files)
- Corrected some output path issues which generated invalid paths
EDIT:
- Skeleton Name (aka skeleton id string) is stored gltf , and read by importer; 
  - Skeleton Name is added as gltf scene node, for maximum compatibility when re-saving scene or converting to other formats, and so the user can edit / add a skeleton id string to gltf if needed
 - Addes many more checks/throws for potentially invalid containers
 - Fixed path issues with exporter PNG saving
 
