### PR TITLE
Pharaoh WsModel generation fixes, material generation fixes and some unit tests

### DIFF
--- a/GameWorld/View3D/Rendering/Materials/Serialization/WsMaterialTemplateEditor.cs
+++ b/GameWorld/View3D/Rendering/Materials/Serialization/WsMaterialTemplateEditor.cs
@@ -72,7 +72,7 @@ namespace GameWorld.Core.Rendering.Materials.Serialization
                 UiVertexFormat.Weighted => "weighted2",
                 _ => throw new Exception("Unknown vertex type")
             };
-            if (GameHint == GameTypeEnum.Pharaoh)
+            if (GameHint == GameTypeEnum.Pharaoh) //Pharaoh does not require alpha and the naming is different as well as the template
             {
                 materialVertexFormatStr = vertexFormat switch
                 {
@@ -81,7 +81,7 @@ namespace GameWorld.Core.Rendering.Materials.Serialization
                     UiVertexFormat.Weighted => "weighted_standard_2",
                     _ => throw new Exception("Unknown vertex type")
                 };
-                fileName = $"{meshName}_{materialVertexFormatStr}.xml";
+                fileName = $"{meshName}_{materialVertexFormatStr}.xml";//no alpha attribute in template
                 AddAttribute("TEMPLATE_ATTR_FILE_NAME", fileName);
                 AddAttribute("TEMPLATE_ATTR_VERTEXTYPE", materialVertexFormatStr);
                 return $"{fileName}.material"; ;

--- a/GameWorld/View3D/Rendering/Materials/Serialization/WsMaterialTemplateEditor.cs
+++ b/GameWorld/View3D/Rendering/Materials/Serialization/WsMaterialTemplateEditor.cs
@@ -57,6 +57,7 @@ namespace GameWorld.Core.Rendering.Materials.Serialization
         {
             var alphaShaderPart = "";
             var alphaNamePart = "off";
+            var fileName = "";
 
             var baseCapability = capabilityMaterial.TryGetCapability<MaterialBaseCapability>();
             if (baseCapability != null && baseCapability.UseAlpha)
@@ -64,7 +65,6 @@ namespace GameWorld.Core.Rendering.Materials.Serialization
                 alphaShaderPart = "_alpha";
                 alphaNamePart = "on";
             }
-
             var materialVertexFormatStr = vertexFormat switch
             {
                 UiVertexFormat.Static => "rigid",
@@ -72,8 +72,22 @@ namespace GameWorld.Core.Rendering.Materials.Serialization
                 UiVertexFormat.Weighted => "weighted2",
                 _ => throw new Exception("Unknown vertex type")
             };
+            if (GameHint == GameTypeEnum.Pharaoh)
+            {
+                materialVertexFormatStr = vertexFormat switch
+                {
+                    UiVertexFormat.Static => "rigid",
+                    UiVertexFormat.Cinematic => "weighted_standard_4",
+                    UiVertexFormat.Weighted => "weighted_standard_2",
+                    _ => throw new Exception("Unknown vertex type")
+                };
+                fileName = $"{meshName}_{materialVertexFormatStr}.xml";
+                AddAttribute("TEMPLATE_ATTR_FILE_NAME", fileName);
+                AddAttribute("TEMPLATE_ATTR_VERTEXTYPE", materialVertexFormatStr);
+                return $"{fileName}.material"; ;
+            }
 
-            var fileName = $"{meshName}_{materialVertexFormatStr}_alpha_{alphaNamePart}.xml";
+            fileName = $"{meshName}_{materialVertexFormatStr}_alpha_{alphaNamePart}.xml";
             AddAttribute("TEMPLATE_ATTR_FILE_NAME", fileName);
             AddAttribute("TEMPLATE_ATTR_ALPHAMODE", alphaShaderPart);
             AddAttribute("TEMPLATE_ATTR_VERTEXTYPE", materialVertexFormatStr);

--- a/Shared/EmbeddedResources/Resources/WsModelTemplates/MaterialTemplate_pharaoh_default.xml
+++ b/Shared/EmbeddedResources/Resources/WsModelTemplates/MaterialTemplate_pharaoh_default.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" ?>
 <material>
     <name>TEMPLATE_ATTR_FILE_NAME</name>
-    <shader>shaders/TEMPLATE_ATTR_VERTEXTYPE_characterTEMPLATE_ATTR_ALPHAMODE.xml.shader</shader>
+    <shader>shaders/system/TEMPLATE_ATTR_VERTEXTYPE.xml.shader</shader>
     <sort_override>255</sort_override>
     <textures>
         <texture>

--- a/Testing/GameWorld.Core.Test/Rendering/Shaders/SpecGloss/DefaultMaterialTests.cs
+++ b/Testing/GameWorld.Core.Test/Rendering/Shaders/SpecGloss/DefaultMaterialTests.cs
@@ -94,7 +94,6 @@ namespace GameWorld.Core.Test.Rendering.Shaders.SpecGloss
         [Test]
         [TestCase(GameTypeEnum.Troy)]
         [TestCase(GameTypeEnum.Warhammer2)]
-        [TestCase(GameTypeEnum.Pharaoh)]
         public void GenerateWsMaterial(GameTypeEnum gameType)
         {
             // Arrange
@@ -120,6 +119,35 @@ namespace GameWorld.Core.Test.Rendering.Shaders.SpecGloss
             Assert.That(generatedMaterial.Textures[TextureType.Diffuse], Is.EqualTo($"texturePath/wsmodel/{TextureType.Diffuse}.dds"));
             Assert.That(generatedMaterial.Textures[TextureType.Normal], Is.EqualTo($"texturePath/wsmodel/{TextureType.Normal}.dds"));
             Assert.That(generatedMaterial.Textures[TextureType.Mask], Is.EqualTo($"texturePath/wsmodel/{TextureType.Mask}.dds"));
+        }
+        [Test]
+        [TestCase(GameTypeEnum.Pharaoh)]
+        public void GenerateWsMaterialPharaoh(GameTypeEnum gameType)
+        {
+            //Arrange
+            var wsMaterial = GetWsModelFile();
+
+            //Act
+            var material = GetMaterialFactory(gameType).Create(null, wsMaterial);
+            var serializer = CreateWsMaterialSerializer(gameType);
+            var wsMaterialPath = serializer.ProsessMaterial("custompath/materials", "mymesh", UiVertexFormat.Cinematic, material);
+            var packfile = _pfs.FindFile(wsMaterialPath);
+            var generatedMaterial = new WsModelMaterialFile(packfile);
+
+            // Assert
+            Assert.That(generatedMaterial.VertexType, Is.EqualTo(UiVertexFormat.Cinematic));
+            Assert.That(generatedMaterial.Alpha, Is.EqualTo(false));
+
+            Assert.That(generatedMaterial.ShaderPath, Is.EqualTo("shaders/system/weighted_standard_4.xml.shader"));
+            Assert.That(generatedMaterial.Name, Is.EqualTo("mymesh_weighted_standard_4.xml"));
+
+            Assert.That(generatedMaterial.Textures[TextureType.Specular], Is.EqualTo($"texturePath/wsmodel/{TextureType.Specular}.dds"));
+            if (gameType != GameTypeEnum.Pharaoh)
+                Assert.That(generatedMaterial.Textures[TextureType.Gloss], Is.EqualTo($"texturePath/wsmodel/{TextureType.Gloss}.dds"));
+            Assert.That(generatedMaterial.Textures[TextureType.Diffuse], Is.EqualTo($"texturePath/wsmodel/{TextureType.Diffuse}.dds"));
+            Assert.That(generatedMaterial.Textures[TextureType.Normal], Is.EqualTo($"texturePath/wsmodel/{TextureType.Normal}.dds"));
+            Assert.That(generatedMaterial.Textures[TextureType.Mask], Is.EqualTo($"texturePath/wsmodel/{TextureType.Mask}.dds"));
+
         }
 
         [Test]

--- a/Testing/GameWorld.Core.Test/WsMaterialTemplate/CapabilityMaterialMock.cs
+++ b/Testing/GameWorld.Core.Test/WsMaterialTemplate/CapabilityMaterialMock.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using GameWorld.Core.Rendering.Materials.Shaders;
+using GameWorld.Core.Services;
+
+namespace Test.GameWorld.Core.WsMaterialTemplate
+{
+    public class CapabilityMaterialMock : CapabilityMaterial
+    {
+        public CapabilityMaterialMock(CapabilityMaterialsEnum materialType) : base(materialType, ShaderTypes.Pbr_SpecGloss, null)
+        {
+
+        }
+        protected override CapabilityMaterial CreateCloneInstance()
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/Testing/GameWorld.Core.Test/WsMaterialTemplate/CapabilityMaterialMock.cs
+++ b/Testing/GameWorld.Core.Test/WsMaterialTemplate/CapabilityMaterialMock.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using GameWorld.Core.Rendering.Materials.Shaders;
+﻿using GameWorld.Core.Rendering.Materials.Shaders;
 using GameWorld.Core.Services;
 
 namespace Test.GameWorld.Core.WsMaterialTemplate

--- a/Testing/GameWorld.Core.Test/WsMaterialTemplate/WsMaterialTemplateTests.cs
+++ b/Testing/GameWorld.Core.Test/WsMaterialTemplate/WsMaterialTemplateTests.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using GameWorld.Core.Rendering.Materials.Serialization;
+using GameWorld.Core.Rendering.Materials.Capabilities;
+using GameWorld.Core.Rendering.Materials.Shaders;
+using Shared.Core.Settings;
+using Shared.GameFormats.RigidModel;
+using System.Diagnostics.Contracts;
+
+namespace Test.GameWorld.Core.WsMaterialTemplate
+{
+    public class WsMaterialTemplateTests
+    {
+        [Test] //Pharaoh weighted
+        public void AddTemplateHeader_ReturnCorrectFileNameWeighted()
+        {
+            var material = new CapabilityMaterialMock(CapabilityMaterialsEnum.SpecGlossPbr_Default);
+            var editor = new WsMaterialTemplateEditor(material, GameTypeEnum.Pharaoh);
+            var meshName = "testMesh";
+            var vertexFormat = UiVertexFormat.Weighted;
+
+            var result = editor.AddTemplateHeader(meshName, vertexFormat, material);
+            Assert.That(result, Is.EqualTo("testMesh_weighted_standard_2.xml.material"));
+        }
+        [Test] //Pharaoh static
+        public void AddTemplateHeader_ReturnCorrectFileNameStatic()
+        {
+            var material = new CapabilityMaterialMock(CapabilityMaterialsEnum.SpecGlossPbr_Default);
+            var editor = new WsMaterialTemplateEditor(material, GameTypeEnum.Pharaoh);
+            var meshName = "testMesh";
+            var vertexFormat = UiVertexFormat.Static;
+            var result = editor.AddTemplateHeader(meshName, vertexFormat, material);
+            Assert.That(result, Is.EqualTo("testMesh_rigid.xml.material"));
+        }
+        [Test] //Pharaoh cinematic
+        public void AddTemplateHeader_ReturnCorrectFileNameCinematic()
+        {
+            var material = new CapabilityMaterialMock(CapabilityMaterialsEnum.SpecGlossPbr_Default);
+            var editor = new WsMaterialTemplateEditor(material, GameTypeEnum.Pharaoh);
+            var meshName = "testMesh";
+            var vertexFormat = UiVertexFormat.Cinematic;
+            var result = editor.AddTemplateHeader(meshName, vertexFormat, material);
+            Assert.That(result, Is.EqualTo("testMesh_weighted_standard_4.xml.material"));
+        }
+        [Test] //All other games static no alpha
+        public void AddTemplateHeader_ReturnCorrectFileNameStaticAllOtherGames()
+        {
+            var material = new CapabilityMaterialMock(CapabilityMaterialsEnum.SpecGlossPbr_Default);
+            var editor = new WsMaterialTemplateEditor(material, GameTypeEnum.Warhammer2);
+            var meshName = "testMesh";
+            var vertexFormat = UiVertexFormat.Static;
+            var result = editor.AddTemplateHeader(meshName, vertexFormat, material);
+            Assert.That(result, Is.EqualTo("testMesh_rigid_alpha_off.xml.material"));
+        }
+        [Test] //All other games weighted no alpha
+        public void AddTemplateHeader_ReturnCorrectFileNameWeightedAllOtherGames()
+        {
+            var material = new CapabilityMaterialMock(CapabilityMaterialsEnum.SpecGlossPbr_Default);
+            var editor = new WsMaterialTemplateEditor(material, GameTypeEnum.Warhammer2);
+            var meshName = "testMesh";
+            var vertexFormat = UiVertexFormat.Weighted;
+            var result = editor.AddTemplateHeader(meshName, vertexFormat, material);
+            Assert.That(result, Is.EqualTo("testMesh_weighted2_alpha_off.xml.material"));
+        }
+        [Test] //All other games cinematic no alpha
+        public void AddTemplateHeader_ReturnCorrectFileNameCinematicAllOtherGames()
+        {
+            var material = new CapabilityMaterialMock(CapabilityMaterialsEnum.SpecGlossPbr_Default);
+            var editor = new WsMaterialTemplateEditor(material, GameTypeEnum.Warhammer2);
+            var meshName = "testMesh";
+            var vertexFormat = UiVertexFormat.Cinematic;
+            var result = editor.AddTemplateHeader(meshName, vertexFormat, material);
+            Assert.That(result, Is.EqualTo("testMesh_weighted4_alpha_off.xml.material"));
+        }
+
+    }
+}

--- a/Testing/GameWorld.Core.Test/WsMaterialTemplate/WsMaterialTemplateTests.cs
+++ b/Testing/GameWorld.Core.Test/WsMaterialTemplate/WsMaterialTemplateTests.cs
@@ -1,15 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using NUnit.Framework;
-using GameWorld.Core.Rendering.Materials.Serialization;
-using GameWorld.Core.Rendering.Materials.Capabilities;
+﻿using GameWorld.Core.Rendering.Materials.Serialization;
 using GameWorld.Core.Rendering.Materials.Shaders;
 using Shared.Core.Settings;
 using Shared.GameFormats.RigidModel;
-using System.Diagnostics.Contracts;
 
 namespace Test.GameWorld.Core.WsMaterialTemplate
 {


### PR DESCRIPTION
I verified in game that these changes are working to make the pharaoh wsmodels and material that are generated work in game. We had a couple of issues, the first was the naming of the files where things like weighted_2_character should have been weighted_standard_2. We also had issues revolving around the pharaoh material template. It was pointing to the wrong shaders and naming them improperly. I created tests with a capability material mock class to test that the naming was accurate in the file names. There are six unit tests total.