### PR TITLE
[PR #1] Resolved naming violations within Wwise serialisation

### DIFF
--- a/Editors/Audio/AudioExplorer/AudioExplorerViewModel.cs
+++ b/Editors/Audio/AudioExplorer/AudioExplorerViewModel.cs
@@ -121,10 +121,10 @@ namespace Editors.Audio.AudioExplorer
                 {
                     _soundPlayer.ConvertWemToWav(
                         _audioRepository,
-                        cakSound_V112.AkBankSourceData.akMediaInformation.SourceId,
-                        cakSound_V112.AkBankSourceData.akMediaInformation.FileId,
-                        (int)cakSound_V112.AkBankSourceData.akMediaInformation.uFileOffset,
-                        (int)cakSound_V112.AkBankSourceData.akMediaInformation.uInMemoryMediaSize
+                        cakSound_V112.AkBankSourceData.AkMediaInformation.SourceId,
+                        cakSound_V112.AkBankSourceData.AkMediaInformation.FileId,
+                        (int)cakSound_V112.AkBankSourceData.AkMediaInformation.UFileOffset,
+                        (int)cakSound_V112.AkBankSourceData.AkMediaInformation.UInMemoryMediaSize
                     );
                  
                     return;

--- a/Editors/Audio/BnkCompiler/ObjectGeneration/BnkHeaderBuilder.cs
+++ b/Editors/Audio/BnkCompiler/ObjectGeneration/BnkHeaderBuilder.cs
@@ -15,12 +15,12 @@ namespace Editors.Audio.BnkCompiler.ObjectGeneration
 
             var header = new BkhdHeader()
             {
-                dwBankGeneratorVersion = 0x80000088,
-                dwSoundBankId = soundBankId,
-                dwLanguageId = language,
-                bFeedbackInBank = 0x10,
-                dwProjectID = 2361,
-                padding = BitConverter.GetBytes(0x04)
+                DwBankGeneratorVersion = 0x80000088,
+                DwSoundBankId = soundBankId,
+                DwLanguageId = language,
+                BFeedbackInBank = 0x10,
+                DwProjectId = 2361,
+                Padding = BitConverter.GetBytes(0x04)
             };
 
             return header;

--- a/Editors/Audio/BnkCompiler/ObjectGeneration/Warhammer3/ActionGenerator.cs
+++ b/Editors/Audio/BnkCompiler/ObjectGeneration/Warhammer3/ActionGenerator.cs
@@ -26,9 +26,9 @@ namespace Editors.Audio.BnkCompiler.ObjectGeneration.Warhammer3
             wwiseAction.Id = inputAction.Id;
             wwiseAction.Type = HircType.Action;
             wwiseAction.ActionType = ActionType.Play;
-            wwiseAction.idExt = inputAction.ChildId;
-            wwiseAction.AkPlayActionParams.byBitVector = 0x04;
-            wwiseAction.AkPlayActionParams.bankId = WwiseHash.Compute(project.ProjectSettings.BnkName);
+            wwiseAction.IdExt = inputAction.ChildId;
+            wwiseAction.AkPlayActionParams.ByBitVector = 0x04;
+            wwiseAction.AkPlayActionParams.BankId = WwiseHash.Compute(project.ProjectSettings.BnkName);
             wwiseAction.UpdateSize();
 
             return wwiseAction;

--- a/Editors/Audio/BnkCompiler/ObjectGeneration/Warhammer3/DialogueEventGenerator.cs
+++ b/Editors/Audio/BnkCompiler/ObjectGeneration/Warhammer3/DialogueEventGenerator.cs
@@ -44,19 +44,19 @@ namespace Editors.Audio.BnkCompiler.ObjectGeneration.Warhammer3
             {
                 var argument = new ArgumentList.Argument
                 {
-                    ulGroupId = WwiseHash.Compute(stateGroup),
-                    eGroupType = AkGroupType.State
+                    UlGroupId = WwiseHash.Compute(stateGroup),
+                    EGroupType = AkGroupType.State
                 };
                 wwiseDialogueEvent.CustomArgumentList.Add(argument);
             }
 
-            wwiseDialogueEvent.uTreeDepth = (uint)wwiseDialogueEvent.CustomArgumentList.Count();
-            wwiseDialogueEvent.uTreeDataSize = inputDialogueEvent.NodesCount * 12;
-            wwiseDialogueEvent.uProbability = 100;
+            wwiseDialogueEvent.UTreeDepth = (uint)wwiseDialogueEvent.CustomArgumentList.Count();
+            wwiseDialogueEvent.UTreeDataSize = inputDialogueEvent.NodesCount * 12;
+            wwiseDialogueEvent.UProbability = 100;
 
-            wwiseDialogueEvent.uMode = (byte)AkMode.BestMatch;
+            wwiseDialogueEvent.UMode = (byte)AkMode.BestMatch;
 
-            wwiseDialogueEvent.CustomAkDecisionTree = AkDecisionTree.ReflattenTree(inputDialogueEvent.RootNode, wwiseDialogueEvent.uTreeDepth);
+            wwiseDialogueEvent.CustomAkDecisionTree = AkDecisionTree.ReflattenTree(inputDialogueEvent.RootNode, wwiseDialogueEvent.UTreeDepth);
 
             wwiseDialogueEvent.AkPropBundle0 = 0;
             wwiseDialogueEvent.AkPropBundle1 = 0;

--- a/Editors/Audio/BnkCompiler/ObjectGeneration/Warhammer3/RandomContainerGenerator.cs
+++ b/Editors/Audio/BnkCompiler/ObjectGeneration/Warhammer3/RandomContainerGenerator.cs
@@ -26,11 +26,11 @@ namespace Editors.Audio.BnkCompiler.ObjectGeneration.Warhammer3
             wwiseRandomContainer.Id = inputContainer.Id;
             wwiseRandomContainer.Type = HircType.SequenceContainer;
             wwiseRandomContainer.NodeBaseParams = NodeBaseParams.CreateDefaultRandomContainer();
-            wwiseRandomContainer.byBitVector = 0x12;
-            wwiseRandomContainer.fTransitionTime = 1000;
+            wwiseRandomContainer.ByBitVector = 0x12;
+            wwiseRandomContainer.FTransitionTime = 1000;
             wwiseRandomContainer.NodeBaseParams.DirectParentId = inputContainer.DirectParentId;
-            wwiseRandomContainer.sLoopCount = 1;
-            wwiseRandomContainer.wAvoidRepeatCount = 2;
+            wwiseRandomContainer.SLoopCount = 1;
+            wwiseRandomContainer.WAvoidRepeatCount = 2;
 
             var allChildIds = inputContainer.Children.Select(x => x).OrderBy(x => x).ToList();
             wwiseRandomContainer.Children = CreateChildrenList(allChildIds);

--- a/Editors/Audio/BnkCompiler/ObjectGeneration/Warhammer3/SoundGenerator.cs
+++ b/Editors/Audio/BnkCompiler/ObjectGeneration/Warhammer3/SoundGenerator.cs
@@ -46,11 +46,11 @@ namespace Editors.Audio.BnkCompiler.ObjectGeneration.Warhammer3
                 {
                     PluginId = 0x00040001, // [VORBIS]
                     StreamType = SourceType.Streaming,
-                    akMediaInformation = new AkMediaInformation()
+                    AkMediaInformation = new AkMediaInformation()
                     {
                         SourceId = uint.Parse(wavFileName),
-                        uInMemoryMediaSize = (uint)file.DataSource.Size,
-                        uSourceBits = 0x01,
+                        UInMemoryMediaSize = (uint)file.DataSource.Size,
+                        USourceBits = 0x01,
                     }
                 },
                 NodeBaseParams = nodeBaseParams

--- a/Editors/Audio/BnkCompiler/ProjectLoaderHelpers.cs
+++ b/Editors/Audio/BnkCompiler/ProjectLoaderHelpers.cs
@@ -48,9 +48,9 @@ namespace Editors.Audio.BnkCompiler
             //var wwiseIdStart = input.Settings.WwiseStartId;
 
             //if (wwiseIdStart == 0)
-                //UsableWwiseId = 1;
+            //UsableWwiseId = 1;
             //else
-                //UsableWwiseId = wwiseIdStart;
+            //UsableWwiseId = wwiseIdStart;
 
             // Add mixers to compilerData first so they can be individually referenced later.
             AddDialogueEventMixers(audioRepository, mixers, input, compilerData);
@@ -65,9 +65,9 @@ namespace Editors.Audio.BnkCompiler
 
                 uint key = 0; // Any value will initialise this property. In the case of the WH3 Dialogue Events the root node value always exists and is always 0.
                 uint audioNodeId = 0; // If 0 this property is not initialised. The root node in WH3 Dialogue Events is always unused so the value is set to 0.
-                ushort children_uIdx = 1; // If 0 this property is not initialised. This value is set to 1 to initialise the value. Its intended value is updated later.
-                ushort children_uCount = 1; // If 0 this property is not initialised. This value is set to 1 to initialise the value. Its intended value is updated later.
-                var rootNode = CreateNode(key, audioNodeId, children_uIdx, children_uCount, CompilerConstants.UWeight, CompilerConstants.UProbability);
+                ushort childrenUIdx = 1; // If 0 this property is not initialised. This value is set to 1 to initialise the value. Its intended value is updated later.
+                ushort childrenUCount = 1; // If 0 this property is not initialised. This value is set to 1 to initialise the value. Its intended value is updated later.
+                var rootNode = CreateNode(key, audioNodeId, childrenUIdx, childrenUCount, CompilerConstants.UWeight, CompilerConstants.UProbability);
 
                 dialogueEvent.Name = hircDialogueEvent.DialogueEvent;
                 dialogueEvent.Id = eventId;
@@ -295,9 +295,9 @@ namespace Editors.Audio.BnkCompiler
                 else
                 {
                     var audioNodeId = currentStateIndex == statePathArray.Length ? containerId : 0; // If 0 this property is not initialised. If this is the last state in the path AudioNodeId is set to containerId, otherwise it's set to 0 which removes the property.
-                    var children_uIdx = (ushort)(currentStateIndex == statePathArray.Length ? 0 : 1); // If 0 this property is not initialised. If this is the last state in the path Children_uIdx is set to 0 which removes the property otherwise it's set to 1 which means the property can be set later on.
-                    var children_uCount = (ushort)(currentStateIndex == statePathArray.Length ? 0 : 1); // If 0 this property is not initialised. If this is the last state in the path Children_uCount is set to 0 which removes the property otherwise it's set to 1 which means the property can be set later on.
-                    var newNode = CreateNode(hashedState, audioNodeId, children_uIdx, children_uCount, CompilerConstants.UWeight, CompilerConstants.UProbability);
+                    var childrenUIdx = (ushort)(currentStateIndex == statePathArray.Length ? 0 : 1); // If 0 this property is not initialised. If this is the last state in the path Children_uIdx is set to 0 which removes the property otherwise it's set to 1 which means the property can be set later on.
+                    var childrenUCount = (ushort)(currentStateIndex == statePathArray.Length ? 0 : 1); // If 0 this property is not initialised. If this is the last state in the path Children_uCount is set to 0 which removes the property otherwise it's set to 1 which means the property can be set later on.
+                    var newNode = CreateNode(hashedState, audioNodeId, childrenUIdx, childrenUCount, CompilerConstants.UWeight, CompilerConstants.UProbability);
                     parentNode.Children.Add(newNode);
                     parentNode = newNode;
                 }
@@ -356,14 +356,14 @@ namespace Editors.Audio.BnkCompiler
             };
         }
 
-        public static AkDecisionTree.Node CreateNode(uint key, uint audioNodeId, ushort children_uIdx, ushort children_uCount, ushort uWeight, ushort uProbability)
+        public static AkDecisionTree.Node CreateNode(uint key, uint audioNodeId, ushort childrenUIdx, ushort childrenUCount, ushort uWeight, ushort uProbability)
         {
             return new AkDecisionTree.Node(new AkDecisionTree.BinaryNode
             {
                 Key = key,
                 AudioNodeId = audioNodeId,
-                Children_uIdx = children_uIdx,
-                Children_uCount = children_uCount,
+                ChildrenUIdx = childrenUIdx,
+                ChildrenUCount = childrenUCount,
                 UWeight = uWeight,
                 UProbability = uProbability
             });
@@ -426,8 +426,8 @@ namespace Editors.Audio.BnkCompiler
             Console.WriteLine($"======================= PRINTING CUSTOM DECISION TREE GRAPH =======================");
             Console.WriteLine($"{indentation}Key: {node.Key}");
             Console.WriteLine($"{indentation}AudioNodeId: {node.AudioNodeId}");
-            Console.WriteLine($"{indentation}Children_uIdx: {node.Children_uIdx}");
-            Console.WriteLine($"{indentation}Children_uCount: {node.Children_uCount}");
+            Console.WriteLine($"{indentation}Children_uIdx: {node.ChildrenUIdx}");
+            Console.WriteLine($"{indentation}Children_uCount: {node.ChildrenUCount}");
             Console.WriteLine($"{indentation}uWeight: {node.UWeight}");
             Console.WriteLine($"{indentation}uProbability: {node.UProbability}");
 

--- a/Editors/Audio/Utility/DecisionPathHelper.cs
+++ b/Editors/Audio/Utility/DecisionPathHelper.cs
@@ -1,11 +1,10 @@
-﻿using Editors.Audio.Storage;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Editors.Audio.Storage;
 using Shared.GameFormats.WWise.Hirc;
 using Shared.GameFormats.WWise.Hirc.Shared;
 using Shared.GameFormats.WWise.Hirc.V136;
-using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
 
 namespace Editors.Audio.Utility
 {
@@ -62,13 +61,13 @@ namespace Editors.Audio.Utility
             var arguments = argumentsList.Arguments
                 .Select(x =>
                 {
-                    var name = _audioRepository.GetNameFromHash(x.ulGroupId);
-                    return new { Name = name, x.ulGroupId };
+                    var name = _audioRepository.GetNameFromHash(x.UlGroupId);
+                    return new { Name = name, x.UlGroupId };
                 }).ToList();
 
             var decisionPathCollection = new DecisionPathCollection()
             {
-                Header = new DecisionPath() { Items = arguments.Select(x => new DecisionPathItem() { DisplayName = x.Name, Value = x.ulGroupId }).ToList() },
+                Header = new DecisionPath() { Items = arguments.Select(x => new DecisionPathItem() { DisplayName = x.Name, Value = x.UlGroupId }).ToList() },
                 Paths = decisionPath
             };
 

--- a/Editors/Audio/Utility/WWiseTreeParserChildren.cs
+++ b/Editors/Audio/Utility/WWiseTreeParserChildren.cs
@@ -86,7 +86,7 @@ namespace Editors.Audio.Utility
 
                 foreach (var musicSwitch in musicSwitches)
                 {
-                    var allArgs = musicSwitch.ArgumentList.Arguments.Select(x => x.ulGroupId).ToList();
+                    var allArgs = musicSwitch.ArgumentList.Arguments.Select(x => x.UlGroupId).ToList();
                     if (allArgs.Contains(stateGroupId))
                         ProcessNext(musicSwitch.Id, actionTreeNode);
                 }
@@ -99,7 +99,7 @@ namespace Editors.Audio.Utility
                    .ToList();
 
                 foreach (var normalSwitch in normalSwitches)
-                    if (normalSwitch.ulGroupID == stateGroupId)
+                    if (normalSwitch.UlGroupId == stateGroupId)
                         ProcessNext(normalSwitch.Id, actionTreeNode);
             }
             else ProcessNext(childId, actionTreeNode);
@@ -208,9 +208,9 @@ namespace Editors.Audio.Utility
             var node = new HircTreeItem() { DisplayName = $"Music Rand Container", Item = item };
             parent.Children.Add(node);
 
-            if (hirc.pPlayList.Count != 0)
-                foreach (var playList in hirc.pPlayList.First().pPlayList)
-                    ProcessNext(playList.SegmentID, node);
+            if (hirc.PPlayList.Count != 0)
+                foreach (var playList in hirc.PPlayList.First().PPlayList)
+                    ProcessNext(playList.SegmentId, node);
         }
     }
 }

--- a/Shared/GameFiles/WWise/Bkhd/BkhdHeader.cs
+++ b/Shared/GameFiles/WWise/Bkhd/BkhdHeader.cs
@@ -3,15 +3,12 @@
     public class BkhdHeader
     {
         public string OwnerFileName { get; set; }
-
         public BnkChunkHeader ChunkHeader { get; set; } = new BnkChunkHeader() { Tag = "BKHD", ChunkSize = 0x18 };
-
-        public uint dwBankGeneratorVersion { get; set; }
-        public uint dwSoundBankId { get; set; }     // Name of the file
-        public uint dwLanguageId { get; set; }      // Enum 11 - English
-        public uint bFeedbackInBank { get; set; }
-        public uint dwProjectID { get; set; }
-        public byte[] padding { get; set; }
+        public uint DwBankGeneratorVersion { get; set; }
+        public uint DwSoundBankId { get; set; }
+        public uint DwLanguageId { get; set; }
+        public uint BFeedbackInBank { get; set; }
+        public uint DwProjectId { get; set; }
+        public byte[] Padding { get; set; }
     }
-
 }

--- a/Shared/GameFiles/WWise/Bkhd/BkhdParser.cs
+++ b/Shared/GameFiles/WWise/Bkhd/BkhdParser.cs
@@ -4,33 +4,33 @@ namespace Shared.GameFormats.WWise.Bkhd
 {
     public class BkhdParser
     {
-        public BkhdHeader Parse(string fileName, ByteChunk chunk)
+        public static BkhdHeader Parse(string fileName, ByteChunk chunk)
         {
             var bkdh = new BkhdHeader()
             {
                 OwnerFileName = fileName,
                 ChunkHeader = BnkChunkHeader.CreateFromBytes(chunk),
 
-                dwBankGeneratorVersion = chunk.ReadUInt32(),
-                dwSoundBankId = chunk.ReadUInt32(),
-                dwLanguageId = chunk.ReadUInt32(),
-                bFeedbackInBank = chunk.ReadUInt32(),
-                dwProjectID = chunk.ReadUInt32(),
+                DwBankGeneratorVersion = chunk.ReadUInt32(),
+                DwSoundBankId = chunk.ReadUInt32(),
+                DwLanguageId = chunk.ReadUInt32(),
+                BFeedbackInBank = chunk.ReadUInt32(),
+                DwProjectId = chunk.ReadUInt32(),
             };
 
             // Read the padding
             var headerDiff = (int)bkdh.ChunkHeader.ChunkSize - 20;
             if (headerDiff > 0)
-                bkdh.padding = chunk.ReadBytes(headerDiff);
+                bkdh.Padding = chunk.ReadBytes(headerDiff);
 
             // Sometimes the version number is strange, probably because CA has their own compiled 
             // version of WWISE. Their version is based on an official version, so we map it to the
             // closest known ID
-            if (bkdh.dwBankGeneratorVersion == 2147483770)
-                bkdh.dwBankGeneratorVersion = 122;
+            if (bkdh.DwBankGeneratorVersion == 2147483770)
+                bkdh.DwBankGeneratorVersion = 122;
 
-            if (bkdh.dwBankGeneratorVersion == 2147483784)
-                bkdh.dwBankGeneratorVersion = 136;
+            if (bkdh.DwBankGeneratorVersion == 2147483784)
+                bkdh.DwBankGeneratorVersion = 136;
 
             return bkdh;
         }
@@ -39,17 +39,17 @@ namespace Shared.GameFormats.WWise.Bkhd
         {
             using var memStream = new MemoryStream();
             memStream.Write(BnkChunkHeader.GetAsByteArray(header.ChunkHeader));
-            memStream.Write(ByteParsers.UInt32.EncodeValue(header.dwBankGeneratorVersion, out _));
-            memStream.Write(ByteParsers.UInt32.EncodeValue(header.dwSoundBankId, out _));
-            memStream.Write(ByteParsers.UInt32.EncodeValue(header.dwLanguageId, out _));
-            memStream.Write(ByteParsers.UInt32.EncodeValue(header.bFeedbackInBank, out _));
-            memStream.Write(ByteParsers.UInt32.EncodeValue(header.dwProjectID, out _));
-            memStream.Write(header.padding);
+            memStream.Write(ByteParsers.UInt32.EncodeValue(header.DwBankGeneratorVersion, out _));
+            memStream.Write(ByteParsers.UInt32.EncodeValue(header.DwSoundBankId, out _));
+            memStream.Write(ByteParsers.UInt32.EncodeValue(header.DwLanguageId, out _));
+            memStream.Write(ByteParsers.UInt32.EncodeValue(header.BFeedbackInBank, out _));
+            memStream.Write(ByteParsers.UInt32.EncodeValue(header.DwProjectId, out _));
+            memStream.Write(header.Padding);
             var byteArray = memStream.ToArray();
 
             // Reload the object to ensure sanity
             var parser = new BkhdParser();
-            parser.Parse("name", new ByteChunk(byteArray));
+            Parse("name", new ByteChunk(byteArray));
 
             return byteArray;
         }

--- a/Shared/GameFiles/WWise/BnkChunkHeader.cs
+++ b/Shared/GameFiles/WWise/BnkChunkHeader.cs
@@ -43,10 +43,3 @@ namespace Shared.GameFormats.WWise
         }
     }
 }
-
-//https://wiki.xentax.com/index.php/Wwise_SoundBank_(*.bnk)#DIDX_section
-//https://github.com/bnnm/wwiser/blob/cd5c086ef2c104e7133e361d385a1023408fb92f/wwiser/wmodel.py#L205
-//https://github.com/Maddoxkkm/bnk-event-extraction
-//https://github.com/vgmstream/vgmstream/blob/37cc12295c92ec6aa874118fb237bd3821970836/src/meta/bkhd.c
-//https://github.com/admiralnelson/total-warhammer-RE-audio/blob/master/BnkExtract.py
-//https://github.com/eXpl0it3r/bnkextr

--- a/Shared/GameFiles/WWise/Bnkparser.cs
+++ b/Shared/GameFiles/WWise/Bnkparser.cs
@@ -10,11 +10,7 @@ namespace Shared.GameFormats.WWise
 {
     public class BnkParser
     {
-        readonly BkhdParser _bkhdParser = new();
         readonly HircParser _hircParser = new();
-        readonly StidParser _stidParser = new();
-        readonly DidxParser _didxParser = new();
-        readonly DataParser _dataParser = new();
 
         public BnkParser()
         {
@@ -34,7 +30,7 @@ namespace Shared.GameFormats.WWise
                 if (WWiseObjectHeaders.BKHD == chunckHeader.Tag)
                     parsedBnkFile.Header = LoadHeader(fullName, chunk);
                 else if (WWiseObjectHeaders.HIRC == chunckHeader.Tag)
-                    parsedBnkFile.HircChuck = LoadHircs(fullName, chunk, chunckHeader.ChunkSize, parsedBnkFile.Header.dwBankGeneratorVersion, isCaHircItem);
+                    parsedBnkFile.HircChuck = LoadHircs(fullName, chunk, chunckHeader.ChunkSize, parsedBnkFile.Header.DwBankGeneratorVersion, isCaHircItem);
                 else if (WWiseObjectHeaders.DIDX == chunckHeader.Tag)
                     parsedBnkFile.DidxChunk = LoadDidx(fullName, chunk);
                 else if (WWiseObjectHeaders.DATA == chunckHeader.Tag)
@@ -56,7 +52,7 @@ namespace Shared.GameFormats.WWise
             return parsedBnkFile;
         }
 
-        BkhdHeader LoadHeader(string fullName, ByteChunk chunk) => _bkhdParser.Parse(fullName, chunk);
+        private static BkhdHeader LoadHeader(string fullName, ByteChunk chunk) => BkhdParser.Parse(fullName, chunk);
 
         private HircChunk LoadHircs(string fullName, ByteChunk chunk, uint chunkHeaderSize, uint bnkVersion, bool isCaHircItem)
         {
@@ -71,9 +67,9 @@ namespace Shared.GameFormats.WWise
             return hircData;
         }
 
-        DidxChunk LoadDidx(string fullName, ByteChunk chunk) => _didxParser.Parse(fullName, chunk, null);
-        ByteChunk LoadData(string fullName, ByteChunk chunk) => _dataParser.Parse(fullName, chunk, null);
-        void LoadStid(string fullName, ByteChunk chunk) => _stidParser.Parse(fullName, chunk, null);
+        private static DidxChunk LoadDidx(string fullName, ByteChunk chunk) => DidxParser.Parse(fullName, chunk, null);
+        private static ByteChunk LoadData(string fullName, ByteChunk chunk) => DataParser.Parse(fullName, chunk, null);
+        static void LoadStid(string fullName, ByteChunk chunk) => StidParser.Parse(fullName, chunk, null);
     }
 }
 

--- a/Shared/GameFiles/WWise/Data/DataParser.cs
+++ b/Shared/GameFiles/WWise/Data/DataParser.cs
@@ -5,7 +5,7 @@ namespace Shared.GameFormats.WWise.Data
 {
     public class DataParser
     {
-        public ByteChunk Parse(string fileName, ByteChunk chunk, ParsedBnkFile soundDb)
+        public static ByteChunk Parse(string fileName, ByteChunk chunk, ParsedBnkFile soundDb)
         {
             var tag = Encoding.UTF8.GetString(chunk.ReadBytes(4));
             var chunkSize = chunk.ReadUInt32();

--- a/Shared/GameFiles/WWise/Didx/DidxParser.cs
+++ b/Shared/GameFiles/WWise/Didx/DidxParser.cs
@@ -5,7 +5,7 @@ namespace Shared.GameFormats.WWise.Didx
 {
     public class DidxChunk
     {
-        public List<MediaHeader> MediaList { get; set; } = new();
+        public List<MediaHeader> MediaList { get; set; } = [];
 
         public class MediaHeader
         {
@@ -25,19 +25,17 @@ namespace Shared.GameFormats.WWise.Didx
 
     public class DidxParser
     {
-        public DidxChunk Parse(string fileName, ByteChunk chunk, ParsedBnkFile soundDb)
+        public static DidxChunk Parse(string fileName, ByteChunk chunk, ParsedBnkFile soundDb)
         {
             var tag = Encoding.UTF8.GetString(chunk.ReadBytes(4));
             var chunkSize = chunk.ReadUInt32();
 
             var numItems = chunkSize / DidxChunk.MediaHeader.ByteSize;
-            var MediaListediaList = Enumerable.Range(0, (int)numItems)
+            var mediaListediaList = Enumerable.Range(0, (int)numItems)
                 .Select(x => new DidxChunk.MediaHeader(chunk))
                 .ToList();
 
-            return new DidxChunk { MediaList = MediaListediaList };
+            return new DidxChunk { MediaList = mediaListediaList };
         }
-
-
     }
 }

--- a/Shared/GameFiles/WWise/Enums.cs
+++ b/Shared/GameFiles/WWise/Enums.cs
@@ -1,6 +1,5 @@
 ﻿namespace Shared.GameFormats.WWise
 {
-
     public static class WWiseObjectHeaders
     {
         public const string BKHD = "BKHD";
@@ -21,12 +20,10 @@
         ActorMixer = 0x07,
         Audio_Bus = 0x08,
         LayerContainer = 0x09,
-        //
         Music_Segment = 0x0a,
         Music_Track = 0x0b,
         Music_Switch = 0x0c,
         Music_Random_Sequence = 0x0d,
-        //
         Attenuation = 0x0e,
         Dialogue_Event = 0x0f,
         FxShareSet = 0x10,
@@ -36,7 +33,6 @@
         Envelope = 0x14,
         AudioDevice = 0x15,
         TimeMod = 0x16,
-
         Didx_Audio = 0x17
     }
 

--- a/Shared/GameFiles/WWise/Hirc/ByteHirc.cs
+++ b/Shared/GameFiles/WWise/Hirc/ByteHirc.cs
@@ -16,7 +16,6 @@ namespace Shared.GameFormats.WWise.Hirc
         {
             using var memStream = WriteHeader();
             memStream.Write(HircData);
-
             return memStream.ToArray();
         }
     }

--- a/Shared/GameFiles/WWise/Hirc/CAkUnknown.cs
+++ b/Shared/GameFiles/WWise/Hirc/CAkUnknown.cs
@@ -6,7 +6,6 @@ namespace Shared.GameFormats.WWise.Hirc
     {
         public string ErrorMsg { get; set; }
 
-
         protected override void CreateSpecificData(ByteChunk chunk)
         {
             chunk.ReadBytes((int)Size - 4);

--- a/Shared/GameFiles/WWise/Hirc/HircChunk.cs
+++ b/Shared/GameFiles/WWise/Hirc/HircChunk.cs
@@ -4,13 +4,13 @@
     {
         public BnkChunkHeader ChunkHeader { get; set; } = new BnkChunkHeader() { Tag = "HIRC", ChunkSize = 0 };
         public uint NumHircItems { get; set; }
-        public List<HircItem> Hircs { get; set; } = new List<HircItem>();
+        public List<HircItem> Hircs { get; set; } = [];
 
         public void SetFromHircList(List<HircItem> hircList)
         {
             Hircs.AddRange(hircList);
             ChunkHeader.ChunkSize = (uint)(hircList.Sum(x => x.Size) + hircList.Count() * 5 + 4);
-            NumHircItems = (uint)hircList.Count();
+            NumHircItems = (uint)hircList.Count;
         }
     }
 }

--- a/Shared/GameFiles/WWise/Hirc/HircFactory.cs
+++ b/Shared/GameFiles/WWise/Hirc/HircFactory.cs
@@ -2,7 +2,8 @@
 {
     public class HircFactory
     {
-        Dictionary<HircType, Func<HircItem>> _itemList = new Dictionary<HircType, Func<HircItem>>();
+        private readonly Dictionary<HircType, Func<HircItem>> _itemList = [];
+
         public void RegisterHirc(HircType type, Func<HircItem> creator)
         {
             _itemList[type] = creator;
@@ -25,15 +26,15 @@
         {
             switch (version)
             {
-                case 112: return CreateFactory_v112();  // Atilla
+                case 112: return CreateFactory_v112();
                 case 122: return CreateFactory_v122();
-                case 136: return CreateFactory_v136();  // Wh3
+                case 136: return CreateFactory_v136();
             }
 
             throw new Exception($"Unknown Version {version}");
         }
 
-        static HircFactory CreateFactory_v122()
+        private static HircFactory CreateFactory_v122()
         {
             var instance = new HircFactory();
             instance.RegisterHirc(HircType.Sound, () => new V122.CAkSound_V122());
@@ -46,7 +47,7 @@
             return instance;
         }
 
-        static HircFactory CreateFactory_v112()
+        private static HircFactory CreateFactory_v112()
         {
             var instance = new HircFactory();
             instance.RegisterHirc(HircType.ActorMixer, () => new V112.CAkActorMixer_v112());
@@ -60,7 +61,7 @@
             return instance;
         }
 
-        static HircFactory CreateFactory_v136()
+        private static HircFactory CreateFactory_v136()
         {
             var instance = new HircFactory();
             instance.RegisterHirc(HircType.ActorMixer, () => new V136.CAkActorMixer_v136());

--- a/Shared/GameFiles/WWise/Hirc/HircInterfaces.cs
+++ b/Shared/GameFiles/WWise/Hirc/HircInterfaces.cs
@@ -27,7 +27,6 @@ namespace Shared.GameFormats.WWise.Hirc
         public AkDecisionTree AkDecisionTree { get; }
     }
 
-
     public interface ICAkActorMixer
     {
         public List<uint> GetChildren();
@@ -38,7 +37,6 @@ namespace Shared.GameFormats.WWise.Hirc
     {
         public uint GetDirectParentId();
         public List<ICAkSwitchPackage> SwitchList { get; }
-
         uint GroupId { get; }
         uint DefaultSwitch { get; }
 
@@ -60,16 +58,11 @@ namespace Shared.GameFormats.WWise.Hirc
         public uint GetDirectParentId();
     }
 
-
-    // Convert to interfaces 
-
     public abstract class CAkRanSeqCnt : HircItem
     {
         public abstract uint GetParentId();
         public abstract List<uint> GetChildren();
     }
-
-
 
     public abstract class CAkSwitchCntr : HircItem
     {

--- a/Shared/GameFiles/WWise/Hirc/Shared/AkDecisionTree.cs
+++ b/Shared/GameFiles/WWise/Hirc/Shared/AkDecisionTree.cs
@@ -6,24 +6,25 @@ namespace Shared.GameFormats.WWise.Hirc.Shared
     public class AkDecisionTree
     {
         public Node Root { get; set; }
-        public static List<BinaryNode> flattenedTree;
+        public static List<BinaryNode> FlattenedTree;
 
         public class BinaryNode
         {
             public uint? Key { get; set; }
             public uint AudioNodeId { get; set; }
-            public ushort Children_uIdx { get; set; }
-            public ushort Children_uCount { get; set; }
+            public ushort ChildrenUIdx { get; set; }
+            public ushort ChildrenUCount { get; set; }
             public ushort UWeight { get; set; }
             public ushort UProbability { get; set; }
+
             public static readonly int SerializationByteSize = 12;
 
             public BinaryNode(ByteChunk chunk)
             {
                 Key = chunk.ReadUInt32();
                 AudioNodeId = chunk.PeakUint32();
-                Children_uIdx = chunk.ReadUShort();
-                Children_uCount = chunk.ReadUShort();
+                ChildrenUIdx = chunk.ReadUShort();
+                ChildrenUCount = chunk.ReadUShort();
                 UWeight = chunk.ReadUShort();
                 UProbability = chunk.ReadUShort();
             }
@@ -32,8 +33,8 @@ namespace Shared.GameFormats.WWise.Hirc.Shared
             {
                 Key = 0;
                 AudioNodeId = 0;
-                Children_uIdx = 0;
-                Children_uCount = 0;
+                ChildrenUIdx = 0;
+                ChildrenUCount = 0;
                 UWeight = 0;
                 UProbability = 0;
             }
@@ -44,8 +45,8 @@ namespace Shared.GameFormats.WWise.Hirc.Shared
             public bool IsAudioNode() => Children.Count == 0;
             public uint? Key { get; set; }
             public uint AudioNodeId { get; set; }
-            public ushort Children_uIdx { get; set; }
-            public ushort Children_uCount { get; set; }
+            public ushort ChildrenUIdx { get; set; }
+            public ushort ChildrenUCount { get; set; }
             public ushort UWeight { get; set; }
             public ushort UProbability { get; set; }
             public List<Node> Children { get; set; } = [];
@@ -54,8 +55,8 @@ namespace Shared.GameFormats.WWise.Hirc.Shared
             {
                 Key = sNode.Key;
                 AudioNodeId = sNode.AudioNodeId;
-                Children_uIdx = sNode.Children_uIdx;
-                Children_uCount = sNode.Children_uCount;
+                ChildrenUIdx = sNode.ChildrenUIdx;
+                ChildrenUCount = sNode.ChildrenUCount;
                 UWeight = sNode.UWeight;
                 UProbability = sNode.UProbability;
             }
@@ -70,7 +71,7 @@ namespace Shared.GameFormats.WWise.Hirc.Shared
                     Console.WriteLine(new string(' ', depth * 2) + $"Key: {node.Key}, AudioNodeId: {node.AudioNodeId}, uWeight: {node.UWeight}, uProbability: {node.UProbability}");
 
                 else
-                    Console.WriteLine(new string(' ', depth * 2) + $"Key: {node.Key}, Children_uIdx: {node.Children_uIdx}, Children_uCount: {node.Children_uCount}, uWeight: {node.UWeight}, uProbability: {node.UProbability}");
+                    Console.WriteLine(new string(' ', depth * 2) + $"Key: {node.Key}, Children_uIdx: {node.ChildrenUIdx}, Children_uCount: {node.ChildrenUCount}, uWeight: {node.UWeight}, uProbability: {node.UProbability}");
             }
         }
 
@@ -79,12 +80,11 @@ namespace Shared.GameFormats.WWise.Hirc.Shared
             if (node.AudioNodeId != 0)
                 Console.WriteLine(new string(' ', depth * 2) + $"Key: {node.Key}, AudioNodeId: {node.AudioNodeId}, uWeight: {node.UWeight}, uProbability: {node.UProbability}");
             else
-                Console.WriteLine(new string(' ', depth * 2) + $"Key: {node.Key}, Children_uIdx: {node.Children_uIdx}, Children_uCount: {node.Children_uCount}, uWeight: {node.UWeight}, uProbability: {node.UProbability}");
+                Console.WriteLine(new string(' ', depth * 2) + $"Key: {node.Key}, Children_uIdx: {node.ChildrenUIdx}, Children_uCount: {node.ChildrenUCount}, uWeight: {node.UWeight}, uProbability: {node.UProbability}");
 
             foreach (var child in node.Children)
                 PrintGraph(child, depth + 1);
         }
-
 
         // Sorts nodes into order by ID recursively at each depth level
         private static void SortNodes(Node node)
@@ -99,17 +99,15 @@ namespace Shared.GameFormats.WWise.Hirc.Shared
 
         private static void UpdateChildrenData(Node node, ref ushort childrenId)
         {
-            node.Children_uIdx = childrenId;
+            node.ChildrenUIdx = childrenId;
 
             var childrenCount = node.Children.Count;
-            node.Children_uCount = (ushort)childrenCount;
+            node.ChildrenUCount = (ushort)childrenCount;
 
             childrenId += (ushort)childrenCount; // Incrementing the value in the caller's scope
 
             foreach (var child in node.Children)
-            {
                 UpdateChildrenData(child, ref childrenId); // Pass by reference
-            }
         }
 
         private static int CountNodeDescendants(Node node)
@@ -129,7 +127,7 @@ namespace Shared.GameFormats.WWise.Hirc.Shared
             if (node.AudioNodeId != 0)
                 stringBuilder.AppendLine(new string(' ', depth * 2) + $"Key: {node.Key}, AudioNodeId: {node.AudioNodeId}, uWeight: {node.UWeight}, uProbability: {node.UProbability}");
             else
-                stringBuilder.AppendLine(new string(' ', depth * 2) + $"Key: {node.Key}, Children_uIdx: {node.Children_uIdx}, Children_uCount: {node.Children_uCount}, uWeight: {node.UWeight}, uProbability: {node.UProbability}");
+                stringBuilder.AppendLine(new string(' ', depth * 2) + $"Key: {node.Key}, Children_uIdx: {node.ChildrenUIdx}, Children_uCount: {node.ChildrenUCount}, uWeight: {node.UWeight}, uProbability: {node.UProbability}");
 
             foreach (var child in node.Children)
                 stringBuilder.Append(ConvertGraphToString(child, depth + 1));
@@ -141,21 +139,21 @@ namespace Shared.GameFormats.WWise.Hirc.Shared
         {
             var sNode = flattenedTree[parentsFirstChildIndex + childIndex];
             var isAtMaxDepth = currentDepth == maxTreeDepth;
-            var isOutsideRange = sNode.Children_uIdx >= flattenedTree.Count;
+            var isOutsideRange = sNode.ChildrenUIdx >= flattenedTree.Count;
 
             if (isAtMaxDepth || isOutsideRange)
             {
-                sNode.Children_uIdx = 0;
-                sNode.Children_uCount = 0;
+                sNode.ChildrenUIdx = 0;
+                sNode.ChildrenUCount = 0;
                 return new Node(sNode);
             }
             else
             {
                 sNode.AudioNodeId = 0;
                 var pathNode = new Node(sNode);
-                for (var i = 0; i < sNode.Children_uCount; i++)
+                for (var i = 0; i < sNode.ChildrenUCount; i++)
                 {
-                    var childNode = ConvertListToGraph(flattenedTree, maxTreeDepth, sNode.Children_uIdx, (ushort)i, currentDepth + 1);
+                    var childNode = ConvertListToGraph(flattenedTree, maxTreeDepth, sNode.ChildrenUIdx, (ushort)i, currentDepth + 1);
                     pathNode.Children.Add(childNode);
                 }
                 return pathNode;
@@ -169,8 +167,8 @@ namespace Shared.GameFormats.WWise.Hirc.Shared
             {
                 Key = node.Key,
                 AudioNodeId = node.AudioNodeId,
-                Children_uIdx = node.Children_uIdx,
-                Children_uCount = node.Children_uCount,
+                ChildrenUIdx = node.ChildrenUIdx,
+                ChildrenUCount = node.ChildrenUCount,
                 UWeight = node.UWeight,
                 UProbability = node.UProbability
             };
@@ -204,26 +202,26 @@ namespace Shared.GameFormats.WWise.Hirc.Shared
             Console.WriteLine($"======================= PRINTING CUSTOM DECISION TREE GRAPH =======================");
             PrintGraph(rootNode, 0);
 
-            flattenedTree = new List<BinaryNode>();
-            ConvertGraphToList(rootNode, flattenedTree, 0);
+            FlattenedTree = new List<BinaryNode>();
+            ConvertGraphToList(rootNode, FlattenedTree, 0);
 
             Console.WriteLine($"======================= PRINTING FLATTENED CUSTOM DECISION TREE =======================");
-            PrintBinaryNodes(flattenedTree, 0);
+            PrintBinaryNodes(FlattenedTree, 0);
 
-            return flattenedTree;
+            return FlattenedTree;
         }
 
         public AkDecisionTree(ByteChunk chunk, uint maxTreeDepth, uint uTreeDataSize)
         {
             // Produce initial flattenedTree
-            flattenedTree = new List<BinaryNode>();
+            FlattenedTree = new List<BinaryNode>();
             var numNodes = uTreeDataSize / BinaryNode.SerializationByteSize;
 
             foreach (var item in Enumerable.Range(0, (int)numNodes))
-                flattenedTree.Add(new BinaryNode(chunk));
+                FlattenedTree.Add(new BinaryNode(chunk));
 
             // Convert flattenedTree into a graph
-            Root = ConvertListToGraph(flattenedTree, maxTreeDepth, 0, 0, 0);
+            Root = ConvertListToGraph(FlattenedTree, maxTreeDepth, 0, 0, 0);
 
             // Sort nodes into order by ID at each depth level
             SortNodes(Root);
@@ -238,10 +236,10 @@ namespace Shared.GameFormats.WWise.Hirc.Shared
             //PrintGraph(Root, 0);
         }
 
-        public byte[] GetAsBytes()
+        public static byte[] GetAsBytes()
         {
             using var memStream = new MemoryStream();
-            foreach (var binaryNode in flattenedTree)
+            foreach (var binaryNode in FlattenedTree)
             {
                 //Console.WriteLine($"Writing node: {binaryNode.Key}");
                 memStream.Write(ByteParsers.UInt32.EncodeValue(binaryNode.Key ?? 0, out _), 0, 4);
@@ -254,8 +252,8 @@ namespace Shared.GameFormats.WWise.Hirc.Shared
                 else
                 {
                     // Write Children_uIdx and Children_uCount if AudioNodeId is empty
-                    memStream.Write(ByteParsers.UShort.EncodeValue(binaryNode.Children_uIdx, out _), 0, 2);
-                    memStream.Write(ByteParsers.UShort.EncodeValue(binaryNode.Children_uCount, out _), 0, 2);
+                    memStream.Write(ByteParsers.UShort.EncodeValue(binaryNode.ChildrenUIdx, out _), 0, 2);
+                    memStream.Write(ByteParsers.UShort.EncodeValue(binaryNode.ChildrenUCount, out _), 0, 2);
                 }
 
                 memStream.Write(ByteParsers.UShort.EncodeValue(binaryNode.UWeight, out _), 0, 2);
@@ -279,8 +277,8 @@ namespace Shared.GameFormats.WWise.Hirc.Shared
                 }
                 else
                 {
-                    memStream.Write(ByteParsers.UShort.EncodeValue(binaryNode.Children_uIdx, out _), 0, 2);
-                    memStream.Write(ByteParsers.UShort.EncodeValue(binaryNode.Children_uCount, out _), 0, 2);
+                    memStream.Write(ByteParsers.UShort.EncodeValue(binaryNode.ChildrenUIdx, out _), 0, 2);
+                    memStream.Write(ByteParsers.UShort.EncodeValue(binaryNode.ChildrenUCount, out _), 0, 2);
                 }
 
                 memStream.Write(ByteParsers.UShort.EncodeValue(binaryNode.UWeight, out _), 0, 2);

--- a/Shared/GameFiles/WWise/Hirc/Shared/ArgumentList.cs
+++ b/Shared/GameFiles/WWise/Hirc/Shared/ArgumentList.cs
@@ -4,30 +4,30 @@ namespace Shared.GameFormats.WWise.Hirc.Shared
 {
     public class ArgumentList
     {
-        public List<Argument> Arguments { get; set; } = new List<Argument>();
+        public List<Argument> Arguments { get; set; } = [];
         public ArgumentList(ByteChunk chunk, uint numItems)
         {
             for (uint i = 0; i < numItems; i++)
                 Arguments.Add(new Argument());
 
             for (var i = 0; i < numItems; i++)
-                Arguments[i].ulGroupId = chunk.ReadUInt32();
+                Arguments[i].UlGroupId = chunk.ReadUInt32();
 
             for (var i = 0; i < numItems; i++)
-                Arguments[i].eGroupType = (AkGroupType)chunk.ReadByte();
+                Arguments[i].EGroupType = (AkGroupType)chunk.ReadByte();
         }
 
         public class Argument
         {
-            public uint ulGroupId { get; set; }
-            public AkGroupType eGroupType { get; set; }
+            public uint UlGroupId { get; set; }
+            public AkGroupType EGroupType { get; set; }
         }
 
         public byte[] GetAsBytes()
         {
             using var memStream = new MemoryStream();
-            Arguments.ForEach(e => memStream.Write(ByteParsers.UInt32.EncodeValue(e.ulGroupId, out _)));
-            Arguments.ForEach(e => memStream.Write(ByteParsers.Byte.EncodeValue((byte)e.eGroupType, out _)));
+            Arguments.ForEach(e => memStream.Write(ByteParsers.UInt32.EncodeValue(e.UlGroupId, out _)));
+            Arguments.ForEach(e => memStream.Write(ByteParsers.Byte.EncodeValue((byte)e.EGroupType, out _)));
             var byteArray = memStream.ToArray();
             return byteArray;
         }
@@ -35,8 +35,8 @@ namespace Shared.GameFormats.WWise.Hirc.Shared
         public static byte[] GetCustomArgumentsAsBytes(List<Argument> arguments)
         {
             using var memStream = new MemoryStream();
-            arguments.ForEach(e => memStream.Write(ByteParsers.UInt32.EncodeValue(e.ulGroupId, out _)));
-            arguments.ForEach(e => memStream.Write(ByteParsers.Byte.EncodeValue((byte)e.eGroupType, out _)));
+            arguments.ForEach(e => memStream.Write(ByteParsers.UInt32.EncodeValue(e.UlGroupId, out _)));
+            arguments.ForEach(e => memStream.Write(ByteParsers.Byte.EncodeValue((byte)e.EGroupType, out _)));
             var byteArray = memStream.ToArray();
             return byteArray;
         }

--- a/Shared/GameFiles/WWise/Hirc/V112/CAkAction_v112.cs
+++ b/Shared/GameFiles/WWise/Hirc/V112/CAkAction_v112.cs
@@ -16,7 +16,6 @@ namespace Shared.GameFormats.WWise.Hirc.V112
         public ActionType GetActionType() => ActionType;
         public uint GetChildId() => SoundId;
         public uint GetStateGroupId() => throw new NotImplementedException();
-
         public override void UpdateSize() => throw new NotImplementedException();
         public override byte[] GetAsByteArray() => throw new NotImplementedException();
     }

--- a/Shared/GameFiles/WWise/Hirc/V112/CAkActorMixer_v112.cs
+++ b/Shared/GameFiles/WWise/Hirc/V112/CAkActorMixer_v112.cs
@@ -14,9 +14,7 @@ namespace Shared.GameFormats.WWise.Hirc.V112
         }
 
         public override void UpdateSize() => throw new NotImplementedException();
-
         public override byte[] GetAsByteArray() => throw new NotImplementedException();
-
         public List<uint> GetChildren() => Children.ChildIdList;
         public uint GetDirectParentId() => NodeBaseParams.DirectParentId;
     }

--- a/Shared/GameFiles/WWise/Hirc/V112/CAkDialogueEvent_v112.cs
+++ b/Shared/GameFiles/WWise/Hirc/V112/CAkDialogueEvent_v112.cs
@@ -3,29 +3,24 @@ using Shared.GameFormats.WWise.Hirc.Shared;
 
 namespace Shared.GameFormats.WWise.Hirc.V112
 {
-
-
     public class CAkDialogueEvent_v112 : HircItem, ICADialogEvent
     {
-        public byte uProbability { get; set; }
-        public uint uTreeDepth { get; set; }
+        public byte UProbability { get; set; }
+        public uint UTreeDepth { get; set; }
         public ArgumentList ArgumentList { get; set; }
-        public uint uTreeDataSize { get; set; }
-        public byte uMode { get; set; }
+        public uint UTreeDataSize { get; set; }
+        public byte UMode { get; set; }
         public AkDecisionTree AkDecisionTree { get; set; }
-
 
         protected override void CreateSpecificData(ByteChunk chunk)
         {
-            uProbability = chunk.ReadByte();
-            uTreeDepth = chunk.ReadUInt32();
-            ArgumentList = new ArgumentList(chunk, uTreeDepth);
-            uTreeDataSize = chunk.ReadUInt32();
-            uMode = chunk.ReadByte();
-
-            AkDecisionTree = new AkDecisionTree(chunk, uTreeDepth, uTreeDataSize);
+            UProbability = chunk.ReadByte();
+            UTreeDepth = chunk.ReadUInt32();
+            ArgumentList = new ArgumentList(chunk, UTreeDepth);
+            UTreeDataSize = chunk.ReadUInt32();
+            UMode = chunk.ReadByte();
+            AkDecisionTree = new AkDecisionTree(chunk, UTreeDepth, UTreeDataSize);
         }
-
 
         public override void UpdateSize() => throw new NotImplementedException();
         public override byte[] GetAsByteArray() => throw new NotImplementedException();

--- a/Shared/GameFiles/WWise/Hirc/V112/CAkEvent_v112.cs
+++ b/Shared/GameFiles/WWise/Hirc/V112/CAkEvent_v112.cs
@@ -9,7 +9,7 @@ namespace Shared.GameFormats.WWise.Hirc.V112
             public uint ActionId { get; set; }
         }
 
-        public List<Action> Actions { get; set; } = new List<Action>();
+        public List<Action> Actions { get; set; } = [];
 
         protected override void CreateSpecificData(ByteChunk chunk)
         {

--- a/Shared/GameFiles/WWise/Hirc/V112/CAkLayerCntr_v112.cs
+++ b/Shared/GameFiles/WWise/Hirc/V112/CAkLayerCntr_v112.cs
@@ -6,11 +6,9 @@ namespace Shared.GameFormats.WWise.Hirc.V112
     {
         public NodeBaseParams NodeBaseParams { get; set; }
         public Children Children { get; set; }
-        public List<CAkLayer> LayerList { get; set; } = new List<CAkLayer>();
-        public byte bIsContinuousValidation { get; set; }
+        public List<CAkLayer> LayerList { get; set; } = [];
+        public byte BIsContinuousValidation { get; set; }
         public uint GetDirectParentId() => NodeBaseParams.DirectParentId;
-
-
 
         protected override void CreateSpecificData(ByteChunk chunk)
         {
@@ -21,53 +19,50 @@ namespace Shared.GameFormats.WWise.Hirc.V112
             for (var i = 0; i < layerCount; i++)
                 LayerList.Add(CAkLayer.Create(chunk));
 
-            bIsContinuousValidation = chunk.ReadByte();
+            BIsContinuousValidation = chunk.ReadByte();
         }
 
         public override void UpdateSize() => throw new NotImplementedException();
         public override byte[] GetAsByteArray() => throw new NotImplementedException();
-
         public List<uint> GetChildren() => Children.ChildIdList;
     }
 
     public class CAkLayer
     {
-        public uint ulLayerID { get; set; }
-        public InitialRTPC InitialRTPC { get; set; }
-        public uint rtpcID { get; set; }    // Attribute name
-        public AkRtpcType rtpcType { get; set; }
-        public List<CAssociatedChildData> CAssociatedChildDataList { get; set; } = new List<CAssociatedChildData>();
+        public uint UlLayerIr { get; set; }
+        public InitialRtpc InitialRtpc { get; set; }
+        public uint RtpcId { get; set; }
+        public AkRtpcType RtpcType { get; set; }
+        public List<CAssociatedChildData> CAssociatedChildDataList { get; set; } = [];
 
         public static CAkLayer Create(ByteChunk chunk)
         {
             var instance = new CAkLayer();
-            instance.ulLayerID = chunk.ReadUInt32();
-            instance.InitialRTPC = InitialRTPC.Create(chunk);
-            instance.rtpcID = chunk.ReadUInt32();
-            instance.rtpcType = (AkRtpcType)chunk.ReadByte();
+            instance.UlLayerIr = chunk.ReadUInt32();
+            instance.InitialRtpc = InitialRtpc.Create(chunk);
+            instance.RtpcId = chunk.ReadUInt32();
+            instance.RtpcType = (AkRtpcType)chunk.ReadByte();
             var ulNumAssoc = chunk.ReadUInt32();
             for (var i = 0; i < ulNumAssoc; i++)
                 instance.CAssociatedChildDataList.Add(CAssociatedChildData.Create(chunk));
-
             return instance;
         }
     }
 
     public class CAssociatedChildData
     {
-
-        public uint ulAssociatedChildID { get; set; }
-        public uint ulCurveSize { get; set; }
-        public byte unknown_custom1 { get; set; }
-        public List<AkRTPCGraphPoint> AkRTPCGraphPointList { get; set; } = new List<AkRTPCGraphPoint>();
+        public uint UlAssociatedChildId { get; set; }
+        public uint UlCurveSize { get; set; }
+        public byte UnknownCustom1 { get; set; }
+        public List<AkRtpcGraphPoint> AkRtpcGraphPointList { get; set; } = [];
 
         public static CAssociatedChildData Create(ByteChunk chunk)
         {
             var instance = new CAssociatedChildData();
-            instance.ulAssociatedChildID = chunk.ReadUInt32();
-            instance.ulCurveSize = chunk.ReadUInt32();
-            for (var i = 0; i < instance.ulCurveSize; i++)
-                instance.AkRTPCGraphPointList.Add(AkRTPCGraphPoint.Create(chunk));
+            instance.UlAssociatedChildId = chunk.ReadUInt32();
+            instance.UlCurveSize = chunk.ReadUInt32();
+            for (var i = 0; i < instance.UlCurveSize; i++)
+                instance.AkRtpcGraphPointList.Add(AkRtpcGraphPoint.Create(chunk));
             return instance;
         }
     }

--- a/Shared/GameFiles/WWise/Hirc/V112/CAkRanSeqCnt_V112.cs
+++ b/Shared/GameFiles/WWise/Hirc/V112/CAkRanSeqCnt_V112.cs
@@ -2,60 +2,54 @@
 
 namespace Shared.GameFormats.WWise.Hirc.V112
 {
-
     public class CAkRanSeqCnt_V112 : CAkRanSeqCnt
     {
         public NodeBaseParams NodeBaseParams { get; set; }
-
         public ushort LoopCount { get; set; }
-        public ushort sLoopModMin { get; set; }
-        public ushort sLoopModMax { get; set; }
-        public float fTransitionTime { get; set; }
-        public float fTransitionTimeModMin { get; set; }
-        public float fTransitionTimeModMax { get; set; }
-        public ushort wAvoidRepeatCount { get; set; }
-        public byte eTransitionMode { get; set; }
-        public byte eRandomMode { get; set; }
-        public byte eMode { get; set; }
-        public byte byBitVector { get; set; }
-
+        public ushort SLoopModMin { get; set; }
+        public ushort SLoopModMax { get; set; }
+        public float FTransitionTime { get; set; }
+        public float FTransitionTimeModMin { get; set; }
+        public float FTransitionTimeModMax { get; set; }
+        public ushort WAvoidRepeatCount { get; set; }
+        public byte ETransitionMode { get; set; }
+        public byte ERandomMode { get; set; }
+        public byte EMode { get; set; }
+        public byte ByBitVector { get; set; }
         public Children Children { get; set; }
-        public List<AkPlaylistItem> AkPlaylist { get; set; } = new List<AkPlaylistItem>();
+        public List<AkPlaylistItem> AkPlaylist { get; set; } = [];
 
         protected override void CreateSpecificData(ByteChunk chunk)
         {
             NodeBaseParams = NodeBaseParams.Create(chunk);
 
             LoopCount = chunk.ReadUShort();
-            sLoopModMin = chunk.ReadUShort();
-            sLoopModMax = chunk.ReadUShort();
+            SLoopModMin = chunk.ReadUShort();
+            SLoopModMax = chunk.ReadUShort();
 
-            fTransitionTime = chunk.ReadSingle();
-            fTransitionTimeModMin = chunk.ReadSingle();
-            fTransitionTimeModMax = chunk.ReadSingle();
+            FTransitionTime = chunk.ReadSingle();
+            FTransitionTimeModMin = chunk.ReadSingle();
+            FTransitionTimeModMax = chunk.ReadSingle();
 
-            wAvoidRepeatCount = chunk.ReadUShort();
+            WAvoidRepeatCount = chunk.ReadUShort();
 
-            eTransitionMode = chunk.ReadByte();
-            eRandomMode = chunk.ReadByte();
-            eMode = chunk.ReadByte();
-            byBitVector = chunk.ReadByte();
+            ETransitionMode = chunk.ReadByte();
+            ERandomMode = chunk.ReadByte();
+            EMode = chunk.ReadByte();
+            ByBitVector = chunk.ReadByte();
 
             Children = Children.Create(chunk);
 
             var playListItemCount = chunk.ReadUShort();
             for (var i = 0; i < playListItemCount; i++)
                 AkPlaylist.Add(AkPlaylistItem.Create(chunk));
-
         }
 
         public override uint GetParentId() => NodeBaseParams.DirectParentId;
         public override List<uint> GetChildren() => AkPlaylist.Select(x => x.PlayId).ToList();
-
         public override void UpdateSize() => throw new NotImplementedException();
         public override byte[] GetAsByteArray() => throw new NotImplementedException();
     }
-
 
     public class AkPlaylistItem
     {

--- a/Shared/GameFiles/WWise/Hirc/V112/CAkSound_V112.cs
+++ b/Shared/GameFiles/WWise/Hirc/V112/CAkSound_V112.cs
@@ -14,7 +14,7 @@ namespace Shared.GameFormats.WWise.Hirc.V112
         }
 
         public uint GetDirectParentId() => NodeBaseParams.DirectParentId;
-        public uint GetSourceId() => AkBankSourceData.akMediaInformation.SourceId;
+        public uint GetSourceId() => AkBankSourceData.AkMediaInformation.SourceId;
         public SourceType GetStreamType() => AkBankSourceData.StreamType;
 
         public override void UpdateSize() => throw new NotImplementedException();
@@ -24,48 +24,45 @@ namespace Shared.GameFormats.WWise.Hirc.V112
     public class AkBankSourceData
     {
         public uint PluginId { get; set; }
-        public ushort PluginId_type { get; set; }
-        public ushort PluginId_company { get; set; }
+        public ushort PluginIdType { get; set; }
+        public ushort PluginIdCompany { get; set; }
         public SourceType StreamType { get; set; }
+        public AkMediaInformation AkMediaInformation { get; set; }
+        public uint USize { get; set; }
 
-        public AkMediaInformation akMediaInformation { get; set; }
-        public uint uSize { get; set; }
         public static AkBankSourceData Create(ByteChunk chunk)
         {
             var output = new AkBankSourceData()
             {
                 PluginId = chunk.ReadUInt32(),
-                //PluginId_type = chunk.ReadUShort(),
-                //PluginId_company = chunk.ReadUShort(),
                 StreamType = (SourceType)chunk.ReadByte()
             };
 
 
-            output.PluginId_type = (ushort)(output.PluginId >> 0 & 0x000F);
-            output.PluginId_company = (ushort)(output.PluginId >> 4 & 0x03FF);
+            output.PluginIdType = (ushort)(output.PluginId >> 0 & 0x000F);
+            output.PluginIdCompany = (ushort)(output.PluginId >> 4 & 0x03FF);
 
             if (output.StreamType != SourceType.Streaming)
             {
-                //   throw new Exception();
+                //   throw new Exception()
             }
 
-            if (output.PluginId_type == 0x02)
-                output.uSize = chunk.ReadUInt32();
+            if (output.PluginIdType == 0x02)
+                output.USize = chunk.ReadUInt32();
 
-            output.akMediaInformation = AkMediaInformation.Create(chunk, output.StreamType);
+            output.AkMediaInformation = AkMediaInformation.Create(chunk, output.StreamType);
 
             return output;
         }
     }
 
-
     public class AkMediaInformation
     {
         public uint SourceId { get; set; }
         public uint FileId { get; set; }
-        public uint uFileOffset { get; set; }
-        public uint uInMemoryMediaSize { get; set; }
-        public byte uSourceBits { get; set; }
+        public uint UFileOffset { get; set; }
+        public uint UInMemoryMediaSize { get; set; }
+        public byte USourceBits { get; set; }
 
         public static AkMediaInformation Create(ByteChunk chunk, SourceType sourceType)
         {
@@ -73,11 +70,10 @@ namespace Shared.GameFormats.WWise.Hirc.V112
             instance.SourceId = chunk.ReadUInt32();
             instance.FileId = chunk.ReadUInt32();
             if (sourceType == SourceType.Data_BNK)
-                instance.uFileOffset = chunk.ReadUInt32();
-            instance.uInMemoryMediaSize = chunk.ReadUInt32();
-            instance.uSourceBits = chunk.ReadByte();
+                instance.UFileOffset = chunk.ReadUInt32();
+            instance.UInMemoryMediaSize = chunk.ReadUInt32();
+            instance.USourceBits = chunk.ReadByte();
             return instance;
-
         }
     }
 }

--- a/Shared/GameFiles/WWise/Hirc/V112/CAkSwitchCntr_V112.cs
+++ b/Shared/GameFiles/WWise/Hirc/V112/CAkSwitchCntr_V112.cs
@@ -3,25 +3,24 @@ using static Shared.GameFormats.WWise.Hirc.ICAkSwitchCntr;
 
 namespace Shared.GameFormats.WWise.Hirc.V112
 {
-
     public class CAkSwitchCntr_V112 : CAkSwitchCntr, ICAkSwitchCntr
     {
         public NodeBaseParams NodeBaseParams { get; set; }
-        public AkGroupType eGroupType { get; set; }
-        public uint ulGroupID { get; set; }   // Enum group name
-        public uint ulDefaultSwitch { get; set; }    // Default value name
-        public byte bIsContinuousValidation { get; set; }
+        public AkGroupType EGroupType { get; set; }
+        public uint UlGroupId { get; set; }
+        public uint UlDefaultSwitch { get; set; }
+        public byte BIsContinuousValidation { get; set; }
         public Children Children { get; set; }
-        public List<ICAkSwitchPackage> SwitchList { get; set; } = new List<ICAkSwitchPackage>();
-        public List<AkSwitchNodeParams> Parameters { get; set; } = new List<AkSwitchNodeParams>();
+        public List<ICAkSwitchPackage> SwitchList { get; set; } = [];
+        public List<AkSwitchNodeParams> Parameters { get; set; } = [];
 
         protected override void CreateSpecificData(ByteChunk chunk)
         {
             NodeBaseParams = NodeBaseParams.Create(chunk);
-            eGroupType = (AkGroupType)chunk.ReadByte();
-            ulGroupID = chunk.ReadUInt32();
-            ulDefaultSwitch = chunk.ReadUInt32();
-            bIsContinuousValidation = chunk.ReadByte();
+            EGroupType = (AkGroupType)chunk.ReadByte();
+            UlGroupId = chunk.ReadUInt32();
+            UlDefaultSwitch = chunk.ReadUInt32();
+            BIsContinuousValidation = chunk.ReadByte();
             Children = Children.Create(chunk);
 
             var switchListCount = chunk.ReadUInt32();
@@ -31,42 +30,34 @@ namespace Shared.GameFormats.WWise.Hirc.V112
             var paramCount = chunk.ReadUInt32();
             for (var i = 0; i < paramCount; i++)
                 Parameters.Add(AkSwitchNodeParams.Create(chunk));
-
         }
 
-        public override uint GroupId => ulGroupID;
-
-        public override uint DefaultSwitch => ulDefaultSwitch;
-
+        public override uint GroupId => UlGroupId;
+        public override uint DefaultSwitch => UlDefaultSwitch;
         public override uint ParentId => NodeBaseParams.DirectParentId;
-
         public override List<SwitchListItem> Items => SwitchList.Select(x => new SwitchListItem() { SwitchId = x.SwitchId, ChildNodeIds = x.NodeIdList }).ToList();
-
         public override void UpdateSize() => throw new NotImplementedException();
         public override byte[] GetAsByteArray() => throw new NotImplementedException();
-
         public uint GetDirectParentId() => NodeBaseParams.DirectParentId;
     }
 
     public class Children
     {
-        public List<uint> ChildIdList { get; set; } = new List<uint>(); // Probably the name of something, or at least a reference to something interesting
-
+        public List<uint> ChildIdList { get; set; } = [];
         public static Children Create(ByteChunk chunk)
         {
             var instance = new Children();
             var numChildren = chunk.ReadUInt32();
             for (var i = 0; i < numChildren; i++)
                 instance.ChildIdList.Add(chunk.ReadUInt32());
-
             return instance;
         }
     }
 
     public class CAkSwitchPackage : ICAkSwitchPackage
     {
-        public uint SwitchId { get; set; }  // ID/Name of the switch case
-        public List<uint> NodeIdList { get; set; } = new List<uint>(); // Probably the name of something, or at least a reference to something interesting
+        public uint SwitchId { get; set; }
+        public List<uint> NodeIdList { get; set; } = [];
 
         public static ICAkSwitchPackage Create(ByteChunk chunk)
         {
@@ -75,7 +66,6 @@ namespace Shared.GameFormats.WWise.Hirc.V112
             var numChildren = chunk.ReadUInt32();
             for (var i = 0; i < numChildren; i++)
                 instance.NodeIdList.Add(chunk.ReadUInt32());
-
             return instance;
         }
     }
@@ -85,7 +75,6 @@ namespace Shared.GameFormats.WWise.Hirc.V112
         public uint NodeId { get; set; }
         public byte BitVector0 { get; set; }
         public byte BitVector1 { get; set; }
-
         public float FadeOutTime { get; set; }
         public float FadeInTime { get; set; }
 
@@ -97,7 +86,6 @@ namespace Shared.GameFormats.WWise.Hirc.V112
             instance.BitVector1 = chunk.ReadByte();
             instance.FadeOutTime = chunk.ReadSingle();
             instance.FadeInTime = chunk.ReadSingle();
-
             return instance;
         }
     }
@@ -105,41 +93,35 @@ namespace Shared.GameFormats.WWise.Hirc.V112
     public class NodeBaseParams
     {
         public NodeInitialFxParams NodeInitialFxParams { get; set; }
-
-
-        public byte bOverrideAttachmentParams { get; set; }
+        public byte BOverrideAttachmentParams { get; set; }
         public uint OverrideBusId { get; set; }
         public uint DirectParentId { get; set; }
-        public byte byBitVector { get; set; }
-
+        public byte ByBitVector { get; set; }
         public NodeInitialParams NodeInitialParams { get; set; }
         public PositioningParams PositioningParams { get; set; }
         public AuxParams AuxParams { get; set; }
         public AdvSettingsParams AdvSettingsParams { get; set; }
         public StateChunk StateChunk { get; set; }
-        public InitialRTPC InitialRTPC { get; set; }
-
-
-        public byte eGroupType { get; set; } // "Switch"
-        public uint ulGroupID { get; set; }     // Enum switch name
-        public uint ulDefaultSwitch { get; set; }   // Enum switch defautl value
-        public byte bIsContinuousValidation { get; set; } // "Switch"
+        public InitialRtpc InitialRtpc { get; set; }
+        public byte EGroupType { get; set; }
+        public uint UlGroupId { get; set; }
+        public uint UlDefaultSwitch { get; set; }
+        public byte BIsContinuousValidation { get; set; }
 
         public static NodeBaseParams Create(ByteChunk chunk)
         {
             var node = new NodeBaseParams();
             node.NodeInitialFxParams = NodeInitialFxParams.Create(chunk);
-            node.bOverrideAttachmentParams = chunk.ReadByte();
+            node.BOverrideAttachmentParams = chunk.ReadByte();
             node.OverrideBusId = chunk.ReadUInt32();
             node.DirectParentId = chunk.ReadUInt32();
-            node.byBitVector = chunk.ReadByte();
+            node.ByBitVector = chunk.ReadByte();
             node.NodeInitialParams = NodeInitialParams.Create(chunk);
             node.PositioningParams = PositioningParams.Create(chunk);
             node.AuxParams = AuxParams.Create(chunk);
             node.AdvSettingsParams = AdvSettingsParams.Create(chunk);
             node.StateChunk = StateChunk.Create(chunk);
-            node.InitialRTPC = InitialRTPC.Create(chunk);
-
+            node.InitialRtpc = InitialRtpc.Create(chunk);
             return node;
         }
     }
@@ -167,7 +149,7 @@ namespace Shared.GameFormats.WWise.Hirc.V112
             public float Value { get; set; }
         }
 
-        public List<AkPropBundleInstance> Values = new List<AkPropBundleInstance>();
+        public List<AkPropBundleInstance> _values = [];
 
         public static AkPropBundle Create(ByteChunk chunk)
         {
@@ -175,10 +157,10 @@ namespace Shared.GameFormats.WWise.Hirc.V112
             var propsCount = chunk.ReadByte();
 
             for (byte i = 0; i < propsCount; i++)
-                output.Values.Add(new AkPropBundleInstance() { Type = (AkPropBundleType)chunk.ReadByte() });
+                output._values.Add(new AkPropBundleInstance() { Type = (AkPropBundleType)chunk.ReadByte() });
 
             for (byte i = 0; i < propsCount; i++)
-                output.Values[i].Value = chunk.ReadSingle();
+                output._values[i].Value = chunk.ReadSingle();
 
             return output;
         }
@@ -193,7 +175,7 @@ namespace Shared.GameFormats.WWise.Hirc.V112
             public float Max { get; set; }
         }
 
-        public List<AkPropBundleInstance> Values = new List<AkPropBundleInstance>();
+        public List<AkPropBundleInstance> _values = [];
 
         public static AkPropBundleMinMax Create(ByteChunk chunk)
         {
@@ -201,12 +183,12 @@ namespace Shared.GameFormats.WWise.Hirc.V112
             var propsCount = chunk.ReadByte();
 
             for (byte i = 0; i < propsCount; i++)
-                output.Values.Add(new AkPropBundleInstance() { Type = (AkPropBundleType)chunk.ReadByte() });
+                output._values.Add(new AkPropBundleInstance() { Type = (AkPropBundleType)chunk.ReadByte() });
 
             for (byte i = 0; i < propsCount; i++)
             {
-                output.Values[i].Min = chunk.ReadSingle();
-                output.Values[i].Max = chunk.ReadSingle();
+                output._values[i].Min = chunk.ReadSingle();
+                output._values[i].Max = chunk.ReadSingle();
             }
 
             return output;
@@ -215,20 +197,20 @@ namespace Shared.GameFormats.WWise.Hirc.V112
 
     public class NodeInitialFxParams
     {
-        public byte bIsOverrideParentFX { get; set; }
+        public byte BIsOverrideParentFX { get; set; }
 
-        public byte bitsFXBypass { get; set; }
-        public List<FXChunk> FxList { get; set; } = new List<FXChunk>();
+        public byte BitsFXBypass { get; set; }
+        public List<FXChunk> FxList { get; set; } = [];
 
         public static NodeInitialFxParams Create(ByteChunk chunk)
         {
             var instance = new NodeInitialFxParams();
-            instance.bIsOverrideParentFX = chunk.ReadByte();
+            instance.BIsOverrideParentFX = chunk.ReadByte();
             var uNumFx = chunk.ReadByte();
 
             if (uNumFx != 0)
             {
-                instance.bitsFXBypass = chunk.ReadByte();
+                instance.BitsFXBypass = chunk.ReadByte();
                 for (var i = 0; i < uNumFx; i++)
                     instance.FxList.Add(FXChunk.Create(chunk));
             }
@@ -239,51 +221,49 @@ namespace Shared.GameFormats.WWise.Hirc.V112
 
     public class FXChunk
     {
-        public byte uFXIndex { get; set; }
-        public uint fxID { get; set; }
-        public byte bIsShareSet { get; set; }
-        public byte bIsRendered { get; set; }
+        public byte UFXIndex { get; set; }
+        public uint FxId { get; set; }
+        public byte BIsShareSet { get; set; }
+        public byte BIsRendered { get; set; }
 
         public static FXChunk Create(ByteChunk chunk)
         {
             var instance = new FXChunk();
-            instance.uFXIndex = chunk.ReadByte();
-            instance.fxID = chunk.ReadUInt32();
-            instance.bIsShareSet = chunk.ReadByte();
-            instance.bIsRendered = chunk.ReadByte();
+            instance.UFXIndex = chunk.ReadByte();
+            instance.FxId = chunk.ReadUInt32();
+            instance.BIsShareSet = chunk.ReadByte();
+            instance.BIsRendered = chunk.ReadByte();
             return instance;
         }
     }
 
-
     public class PositioningParams
     {
-        public byte uByVector { get; set; }
-        public byte uBits3d { get; set; }
-        public uint uAttenuationID { get; set; }
-
-        public byte ePathMode { get; set; }
+        public byte UByVector { get; set; }
+        public byte UBits3d { get; set; }
+        public uint UAttenuationId { get; set; }
+        public byte EPathMode { get; set; }
         public float TransitionTime { get; set; }
-        public List<AkPathVertex> VertexList { get; set; } = new List<AkPathVertex>();
-        public List<AkPathListItemOffset> PlayListItems { get; set; } = new List<AkPathListItemOffset>();
-        public List<Ak3DAutomationParams> Params { get; set; } = new List<Ak3DAutomationParams>();
+        public List<AkPathVertex> VertexList { get; set; } = [];
+        public List<AkPathListItemOffset> PlayListItems { get; set; } = [];
+        public List<Ak3DAutomationParams> Params { get; set; } = [];
 
         public static PositioningParams Create(ByteChunk chunk)
         {
             var instance = new PositioningParams();
-            instance.uByVector = chunk.ReadByte();
+            instance.UByVector = chunk.ReadByte();
 
-            var bPositioningInfoOverrideParent = (instance.uByVector >> 0 & 1) == 1;
-            var cbIs3DPositioningAvailable = (instance.uByVector >> 3 & 1) == 1;
+            var bPositioningInfoOverrideParent = (instance.UByVector >> 0 & 1) == 1;
+            var cbIs3DPositioningAvailable = (instance.UByVector >> 3 & 1) == 1;
 
             if (bPositioningInfoOverrideParent && cbIs3DPositioningAvailable)
             {
-                instance.uBits3d = chunk.ReadByte();
-                instance.uAttenuationID = chunk.ReadUInt32();
+                instance.UBits3d = chunk.ReadByte();
+                instance.UAttenuationId = chunk.ReadUInt32();
 
-                if ((instance.uBits3d >> 0 & 1) == 0)
+                if ((instance.UBits3d >> 0 & 1) == 0)
                 {
-                    instance.ePathMode = chunk.ReadByte();
+                    instance.EPathMode = chunk.ReadByte();
                     instance.TransitionTime = chunk.ReadSingle();
 
                     var numVertexes = chunk.ReadUInt32();
@@ -294,14 +274,10 @@ namespace Shared.GameFormats.WWise.Hirc.V112
                     for (var i = 0; i < numPlayListItems; i++)
                         instance.PlayListItems.Add(AkPathListItemOffset.Create(chunk));
 
-                    //var numParams = 4;
-                    //if (instance.ePathMode == 0x05)   //StepRandomPickNewPath
-                    //    numParams = 1;
                     for (var i = 0; i < numPlayListItems; i++)
                         instance.Params.Add(Ak3DAutomationParams.Create(chunk));
                 }
             }
-
 
             return instance;
         }
@@ -321,22 +297,20 @@ namespace Shared.GameFormats.WWise.Hirc.V112
             instance.Y = chunk.ReadSingle();
             instance.Z = chunk.ReadSingle();
             instance.Duration = chunk.ReadInt32();
-
             return instance;
         }
     }
 
     public class AkPathListItemOffset
     {
-        public uint ulVerticesOffset { get; set; }
-        public uint iNumVertices { get; set; }
+        public uint UlVerticesOffset { get; set; }
+        public uint INumVertices { get; set; }
 
         public static AkPathListItemOffset Create(ByteChunk chunk)
         {
             var instance = new AkPathListItemOffset();
-            instance.ulVerticesOffset = chunk.ReadUInt32();
-            instance.iNumVertices = chunk.ReadUInt32();
-
+            instance.UlVerticesOffset = chunk.ReadUInt32();
+            instance.INumVertices = chunk.ReadUInt32();
             return instance;
         }
     }
@@ -353,53 +327,46 @@ namespace Shared.GameFormats.WWise.Hirc.V112
             instance.X = chunk.ReadSingle();
             instance.Y = chunk.ReadSingle();
             instance.Z = chunk.ReadSingle();
-
             return instance;
         }
     }
 
     public class AuxParams
     {
-        public byte byBitVector { get; set; }
-        public uint auxID0 { get; set; }
-        public uint auxID1 { get; set; }
-        public uint auxID2 { get; set; }
-        public uint auxID3 { get; set; }
+        public byte ByBitVector { get; set; }
+        public uint AuxId0 { get; set; }
+        public uint AuxId1 { get; set; }
+        public uint AuxId2 { get; set; }
+        public uint AuxId3 { get; set; }
 
         public static AuxParams Create(ByteChunk chunk)
         {
             var instance = new AuxParams();
-            instance.byBitVector = chunk.ReadByte();
-
-            if ((instance.byBitVector >> 3 & 1) == 1)
+            instance.ByBitVector = chunk.ReadByte();
+            if ((instance.ByBitVector >> 3 & 1) == 1)
             {
-                instance.auxID0 = chunk.ReadUInt32();
-                instance.auxID1 = chunk.ReadUInt32();
-                instance.auxID2 = chunk.ReadUInt32();
-                instance.auxID3 = chunk.ReadUInt32();
+                instance.AuxId0 = chunk.ReadUInt32();
+                instance.AuxId1 = chunk.ReadUInt32();
+                instance.AuxId2 = chunk.ReadUInt32();
+                instance.AuxId3 = chunk.ReadUInt32();
             }
-
             return instance;
         }
     }
 
-
     public class AdvSettingsParams
     {
-        public byte byBitVector { get; set; }
-        public byte eVirtualQueueBehavior { get; set; }
-        public ushort u16MaxNumInstance { get; set; }
-        public byte eBelowThresholdBehavior { get; set; }
-        public byte byBitVector2 { get; set; }
-
-
+        public byte ByBitVector { get; set; }
+        public byte EVirtualQueueBehavior { get; set; }
+        public ushort U16MaxNumInstance { get; set; }
+        public byte EBelowThresholdBehavior { get; set; }
+        public byte ByBitVector2 { get; set; }
 
         public static AdvSettingsParams Create(ByteChunk chunk)
         {
-            return new AdvSettingsParams() { byBitVector = chunk.ReadByte(), eVirtualQueueBehavior = chunk.ReadByte(), u16MaxNumInstance = chunk.ReadUShort(), eBelowThresholdBehavior = chunk.ReadByte(), byBitVector2 = chunk.ReadByte() };
+            return new AdvSettingsParams() { ByBitVector = chunk.ReadByte(), EVirtualQueueBehavior = chunk.ReadByte(), U16MaxNumInstance = chunk.ReadUShort(), EBelowThresholdBehavior = chunk.ReadByte(), ByBitVector2 = chunk.ReadByte() };
         }
     }
-
 
     public class StateChunk
     {
@@ -415,18 +382,17 @@ namespace Shared.GameFormats.WWise.Hirc.V112
         }
     }
 
-
     public class AkStateGroupChunk
     {
-        public uint ulStateGroupID { get; set; }
-        public byte eStateSyncType { get; set; }
-        public List<AkState> States { get; set; } = new List<AkState>();
+        public uint UlStateGroupId { get; set; }
+        public byte EStateSyncType { get; set; }
+        public List<AkState> States { get; set; } = [];
 
         public static AkStateGroupChunk Create(ByteChunk chunk)
         {
             var instance = new AkStateGroupChunk();
-            instance.ulStateGroupID = chunk.ReadUInt32();
-            instance.eStateSyncType = chunk.ReadByte();
+            instance.UlStateGroupId = chunk.ReadUInt32();
+            instance.EStateSyncType = chunk.ReadByte();
 
             var count = chunk.ReadUShort();
             for (var i = 0; i < count; i++)
@@ -438,75 +404,73 @@ namespace Shared.GameFormats.WWise.Hirc.V112
 
     public class AkState
     {
-        public uint ulStateID { get; set; }
-        public uint ulStateInstanceID { get; set; }
+        public uint UlStateId { get; set; }
+        public uint UlStateInstanceId { get; set; }
         public static AkState Create(ByteChunk chunk)
         {
             var instance = new AkState();
-            instance.ulStateID = chunk.ReadUInt32();
-            instance.ulStateInstanceID = chunk.ReadUInt32();
+            instance.UlStateId = chunk.ReadUInt32();
+            instance.UlStateInstanceId = chunk.ReadUInt32();
             return instance;
         }
     }
 
-
-    public class InitialRTPC
+    public class InitialRtpc
     {
-        public List<RTPC> RTPCList { get; set; } = new List<RTPC>();
+        public List<Rtpc> RtpcList { get; set; } = [];
 
-        public static InitialRTPC Create(ByteChunk chunk)
+        public static InitialRtpc Create(ByteChunk chunk)
         {
-            var instance = new InitialRTPC();
+            var instance = new InitialRtpc();
             var count = chunk.ReadUShort();
             for (var i = 0; i < count; i++)
-                instance.RTPCList.Add(RTPC.Create(chunk));
+                instance.RtpcList.Add(Rtpc.Create(chunk));
 
             return instance;
         }
     }
 
-    public class RTPC
+    public class Rtpc
     {
-        public uint RTPCID { get; set; }
-        public byte rtpcType { get; set; }
-        public byte rtpcAccum { get; set; }
-        public byte ParamID { get; set; }
-        public uint rtpcCurveID { get; set; }
-        public byte eScaling { get; set; }
-        public List<AkRTPCGraphPoint> pRTPCMgr { get; set; } = new List<AkRTPCGraphPoint>();
+        public uint RtpcId { get; set; }
+        public byte RtpcType { get; set; }
+        public byte RtpcAccum { get; set; }
+        public byte ParamId { get; set; }
+        public uint RtpcCurveId { get; set; }
+        public byte EScaling { get; set; }
+        public List<AkRtpcGraphPoint> PRtpcMgr { get; set; } = [];
 
-        public static RTPC Create(ByteChunk chunk)
+        public static Rtpc Create(ByteChunk chunk)
         {
-            var instance = new RTPC();
-            instance.RTPCID = chunk.ReadUInt32();
-            instance.rtpcType = chunk.ReadByte();
-            instance.rtpcAccum = chunk.ReadByte();
-            instance.ParamID = chunk.ReadByte();
-            instance.rtpcCurveID = chunk.ReadUInt32();
-            instance.eScaling = chunk.ReadByte();
+            var instance = new Rtpc();
+            instance.RtpcId = chunk.ReadUInt32();
+            instance.RtpcType = chunk.ReadByte();
+            instance.RtpcAccum = chunk.ReadByte();
+            instance.ParamId = chunk.ReadByte();
+            instance.RtpcCurveId = chunk.ReadUInt32();
+            instance.EScaling = chunk.ReadByte();
 
             var count = chunk.ReadUShort();
             for (var i = 0; i < count; i++)
-                instance.pRTPCMgr.Add(AkRTPCGraphPoint.Create(chunk));
+                instance.PRtpcMgr.Add(AkRtpcGraphPoint.Create(chunk));
 
             return instance;
         }
     }
 
-    public class AkRTPCGraphPoint
+    public class AkRtpcGraphPoint
     {
         public float From { get; set; }
         public float To { get; set; }
         public uint Interp { get; set; }
 
-        public static AkRTPCGraphPoint Create(ByteChunk chunk)
+        public static AkRtpcGraphPoint Create(ByteChunk chunk)
         {
-            var instance = new AkRTPCGraphPoint();
+            var instance = new AkRtpcGraphPoint();
             instance.From = chunk.ReadSingle();
             instance.To = chunk.ReadSingle();
             instance.Interp = chunk.ReadUInt32();
             return instance;
         }
     }
-
 }

--- a/Shared/GameFiles/WWise/Hirc/V122/CAkAction_V122.cs
+++ b/Shared/GameFiles/WWise/Hirc/V122/CAkAction_V122.cs
@@ -11,16 +11,12 @@ namespace Shared.GameFormats.WWise.Hirc.V122
         {
             ActionType = (ActionType)chunk.ReadUShort();
             SoundId = chunk.ReadUInt32();
-
-            //public AkBankSourceData AkBankSourceData { get; set; }
         }
 
         public ActionType GetActionType() => ActionType;
         public uint GetChildId() => SoundId;
-
         public override void UpdateSize() => throw new NotImplementedException();
         public override byte[] GetAsByteArray() => throw new NotImplementedException();
-
         public uint GetStateGroupId() => throw new NotImplementedException();
     }
 }

--- a/Shared/GameFiles/WWise/Hirc/V122/CAkDialogueEvent_v122.cs
+++ b/Shared/GameFiles/WWise/Hirc/V122/CAkDialogueEvent_v122.cs
@@ -5,22 +5,21 @@ namespace Shared.GameFormats.WWise.Hirc.V122
 {
     public class CAkDialogueEvent_v122 : HircItem, ICADialogEvent
     {
-
-        public byte uProbability { get; set; }
-        public uint uTreeDepth { get; set; }
+        public byte UProbability { get; set; }
+        public uint UTreeDepth { get; set; }
         public ArgumentList ArgumentList { get; set; }
-        public uint uTreeDataSize { get; set; }
-        public byte uMode { get; set; }
+        public uint UTreeDataSize { get; set; }
+        public byte UMode { get; set; }
         public AkDecisionTree AkDecisionTree { get; set; }
 
         protected override void CreateSpecificData(ByteChunk chunk)
         {
-            uProbability = chunk.ReadByte();
-            uTreeDepth = chunk.ReadUInt32();
-            ArgumentList = new ArgumentList(chunk, uTreeDepth);
-            uTreeDataSize = chunk.ReadUInt32();
-            uMode = chunk.ReadByte();
-            AkDecisionTree = new AkDecisionTree(chunk, uTreeDepth, Size);
+            UProbability = chunk.ReadByte();
+            UTreeDepth = chunk.ReadUInt32();
+            ArgumentList = new ArgumentList(chunk, UTreeDepth);
+            UTreeDataSize = chunk.ReadUInt32();
+            UMode = chunk.ReadByte();
+            AkDecisionTree = new AkDecisionTree(chunk, UTreeDepth, Size);
         }
 
         public override void UpdateSize() => throw new NotImplementedException();

--- a/Shared/GameFiles/WWise/Hirc/V122/CAkEvent_v122.cs
+++ b/Shared/GameFiles/WWise/Hirc/V122/CAkEvent_v122.cs
@@ -9,7 +9,7 @@ namespace Shared.GameFormats.WWise.Hirc.V122
             public uint ActionId { get; set; }
         }
 
-        public List<Action> Actions { get; set; } = new List<Action>();
+        public List<Action> Actions { get; set; } = [];
 
         protected override void CreateSpecificData(ByteChunk chunk)
         {

--- a/Shared/GameFiles/WWise/Hirc/V122/CAkLayerCntr_v122.cs
+++ b/Shared/GameFiles/WWise/Hirc/V122/CAkLayerCntr_v122.cs
@@ -6,8 +6,8 @@ namespace Shared.GameFormats.WWise.Hirc.V122
     {
         public NodeBaseParams NodeBaseParams { get; set; }
         public Children Children { get; set; }
-        public List<CAkLayer> LayerList { get; set; } = new List<CAkLayer>();
-        public byte bIsContinuousValidation { get; set; }
+        public List<CAkLayer> LayerList { get; set; } = [];
+        public byte BIsContinuousValidation { get; set; }
         public uint GetDirectParentId() => NodeBaseParams.DirectParentId;
 
         protected override void CreateSpecificData(ByteChunk chunk)
@@ -19,7 +19,7 @@ namespace Shared.GameFormats.WWise.Hirc.V122
             for (var i = 0; i < layerCount; i++)
                 LayerList.Add(CAkLayer.Create(chunk));
 
-            bIsContinuousValidation = chunk.ReadByte();
+            BIsContinuousValidation = chunk.ReadByte();
         }
 
         public override void UpdateSize() => throw new NotImplementedException();
@@ -28,44 +28,42 @@ namespace Shared.GameFormats.WWise.Hirc.V122
 
     public class CAkLayer
     {
-        public uint ulLayerID { get; set; }
-        public InitialRTPC InitialRTPC { get; set; }
-        public uint rtpcID { get; set; }    // Attribute name
-        public AkRtpcType rtpcType { get; set; }
+        public uint UlLayerId { get; set; }
+        public InitialRtpc InitialRtpc { get; set; }
+        public uint RtpcId { get; set; }
+        public AkRtpcType RtpcType { get; set; }
         public List<CAssociatedChildData> CAssociatedChildDataList { get; set; } = new List<CAssociatedChildData>();
 
         public static CAkLayer Create(ByteChunk chunk)
         {
             var instance = new CAkLayer();
-            instance.ulLayerID = chunk.ReadUInt32();
-            instance.InitialRTPC = InitialRTPC.Create(chunk);
-            instance.rtpcID = chunk.ReadUInt32();
-            instance.rtpcType = (AkRtpcType)chunk.ReadByte();
+            instance.UlLayerId = chunk.ReadUInt32();
+            instance.InitialRtpc = InitialRtpc.Create(chunk);
+            instance.RtpcId = chunk.ReadUInt32();
+            instance.RtpcType = (AkRtpcType)chunk.ReadByte();
             var ulNumAssoc = chunk.ReadUInt32();
             for (var i = 0; i < ulNumAssoc; i++)
                 instance.CAssociatedChildDataList.Add(CAssociatedChildData.Create(chunk));
-
             return instance;
         }
     }
 
     public class CAssociatedChildData
     {
-
-        public uint ulAssociatedChildID { get; set; }
-        public byte unknown_custom0 { get; set; }
-        public byte unknown_custom1 { get; set; }
-        public List<AkRTPCGraphPoint> AkRTPCGraphPointList { get; set; } = new List<AkRTPCGraphPoint>();
+        public uint UlAssociatedChildId { get; set; }
+        public byte UnknownCustom0 { get; set; }
+        public byte UnknownCustom1 { get; set; }
+        public List<AkRtpcGraphPoint> AkRtpcGraphPointList { get; set; } = [];
 
         public static CAssociatedChildData Create(ByteChunk chunk)
         {
             var instance = new CAssociatedChildData();
-            instance.ulAssociatedChildID = chunk.ReadUInt32();
-            instance.unknown_custom0 = chunk.ReadByte();
-            instance.unknown_custom1 = chunk.ReadByte();
+            instance.UlAssociatedChildId = chunk.ReadUInt32();
+            instance.UnknownCustom0 = chunk.ReadByte();
+            instance.UnknownCustom1 = chunk.ReadByte();
             var pointCount = chunk.ReadUInt32();
             for (var i = 0; i < pointCount; i++)
-                instance.AkRTPCGraphPointList.Add(AkRTPCGraphPoint.Create(chunk));
+                instance.AkRtpcGraphPointList.Add(AkRtpcGraphPoint.Create(chunk));
             return instance;
         }
     }

--- a/Shared/GameFiles/WWise/Hirc/V122/CAkRanSeqCnt_v122.cs
+++ b/Shared/GameFiles/WWise/Hirc/V122/CAkRanSeqCnt_v122.cs
@@ -2,64 +2,54 @@
 
 namespace Shared.GameFormats.WWise.Hirc.V122
 {
-
-
-
-
-
     public class CAkRanSeqCnt_V122 : CAkRanSeqCnt
     {
         public NodeBaseParams NodeBaseParams { get; set; }
-
         public ushort LoopCount { get; set; }
-        public ushort sLoopModMin { get; set; }
-        public ushort sLoopModMax { get; set; }
-        public float fTransitionTime { get; set; }
-        public float fTransitionTimeModMin { get; set; }
-        public float fTransitionTimeModMax { get; set; }
-        public ushort wAvoidRepeatCount { get; set; }
-        public byte eTransitionMode { get; set; }
-        public byte eRandomMode { get; set; }
-        public byte eMode { get; set; }
-        public byte byBitVector { get; set; }
-
+        public ushort SLoopModMin { get; set; }
+        public ushort SLoopModMax { get; set; }
+        public float FTransitionTime { get; set; }
+        public float FTransitionTimeModMin { get; set; }
+        public float FTransitionTimeModMax { get; set; }
+        public ushort WAvoidRepeatCount { get; set; }
+        public byte ETransitionMode { get; set; }
+        public byte ERandomMode { get; set; }
+        public byte EMode { get; set; }
+        public byte ByBitVector { get; set; }
         public Children Children { get; set; }
-        public List<AkPlaylistItem> AkPlaylist { get; set; } = new List<AkPlaylistItem>();
+        public List<AkPlaylistItem> AkPlaylist { get; set; } = [];
 
         protected override void CreateSpecificData(ByteChunk chunk)
         {
             NodeBaseParams = NodeBaseParams.Create(chunk);
 
             LoopCount = chunk.ReadUShort();
-            sLoopModMin = chunk.ReadUShort();
-            sLoopModMax = chunk.ReadUShort();
+            SLoopModMin = chunk.ReadUShort();
+            SLoopModMax = chunk.ReadUShort();
 
-            fTransitionTime = chunk.ReadSingle();
-            fTransitionTimeModMin = chunk.ReadSingle();
-            fTransitionTimeModMax = chunk.ReadSingle();
+            FTransitionTime = chunk.ReadSingle();
+            FTransitionTimeModMin = chunk.ReadSingle();
+            FTransitionTimeModMax = chunk.ReadSingle();
 
-            wAvoidRepeatCount = chunk.ReadUShort();
+            WAvoidRepeatCount = chunk.ReadUShort();
 
-            eTransitionMode = chunk.ReadByte();
-            eRandomMode = chunk.ReadByte();
-            eMode = chunk.ReadByte();
-            byBitVector = chunk.ReadByte();
+            ETransitionMode = chunk.ReadByte();
+            ERandomMode = chunk.ReadByte();
+            EMode = chunk.ReadByte();
+            ByBitVector = chunk.ReadByte();
 
             Children = Children.Create(chunk);
 
             var playListItemCount = chunk.ReadUShort();
             for (var i = 0; i < playListItemCount; i++)
                 AkPlaylist.Add(AkPlaylistItem.Create(chunk));
-
         }
 
         public override uint GetParentId() => NodeBaseParams.DirectParentId;
         public override List<uint> GetChildren() => AkPlaylist.Select(x => x.PlayId).ToList();
-
         public override void UpdateSize() => throw new NotImplementedException();
         public override byte[] GetAsByteArray() => throw new NotImplementedException();
     }
-
 
     public class AkPlaylistItem
     {

--- a/Shared/GameFiles/WWise/Hirc/V122/CAkSound_V122.cs
+++ b/Shared/GameFiles/WWise/Hirc/V122/CAkSound_V122.cs
@@ -14,7 +14,7 @@ namespace Shared.GameFormats.WWise.Hirc.V122
         }
 
         public uint GetDirectParentId() => NodeBaseParams.DirectParentId;
-        public uint GetSourceId() => AkBankSourceData.akMediaInformation.SourceId;
+        public uint GetSourceId() => AkBankSourceData.AkMediaInformation.SourceId;
         public SourceType GetStreamType() => AkBankSourceData.StreamType;
 
         public override void UpdateSize() => throw new NotImplementedException();
@@ -24,12 +24,12 @@ namespace Shared.GameFormats.WWise.Hirc.V122
     public class AkBankSourceData
     {
         public uint PluginId { get; set; }
-        public ushort PluginId_type { get; set; }
+        public ushort PluginIdType { get; set; }
         public ushort PluginId_company { get; set; }
         public SourceType StreamType { get; set; }
 
-        public AkMediaInformation akMediaInformation { get; set; }
-        public uint uSize { get; set; }
+        public AkMediaInformation AkMediaInformation { get; set; }
+        public uint USize { get; set; }
         public static AkBankSourceData Create(ByteChunk chunk)
         {
             var output = new AkBankSourceData()
@@ -40,8 +40,7 @@ namespace Shared.GameFormats.WWise.Hirc.V122
                 StreamType = (SourceType)chunk.ReadByte()
             };
 
-
-            output.PluginId_type = (ushort)(output.PluginId >> 0 & 0x000F);
+            output.PluginIdType = (ushort)(output.PluginId >> 0 & 0x000F);
             output.PluginId_company = (ushort)(output.PluginId >> 4 & 0x03FF);
 
             if (output.StreamType != SourceType.Streaming)
@@ -49,29 +48,28 @@ namespace Shared.GameFormats.WWise.Hirc.V122
                 //   throw new Exception();
             }
 
-            if (output.PluginId_type == 0x02)
-                output.uSize = chunk.ReadUInt32();
+            if (output.PluginIdType == 0x02)
+                output.USize = chunk.ReadUInt32();
 
-            output.akMediaInformation = AkMediaInformation.Create(chunk);
+            output.AkMediaInformation = AkMediaInformation.Create(chunk);
 
             return output;
         }
     }
 
-
     public class AkMediaInformation
     {
         public uint SourceId { get; set; }
-        public uint uInMemoryMediaSize { get; set; }
-        public byte uSourceBits { get; set; }
+        public uint UInMemoryMediaSize { get; set; }
+        public byte USourceBits { get; set; }
 
         public static AkMediaInformation Create(ByteChunk chunk)
         {
             return new AkMediaInformation()
             {
                 SourceId = chunk.ReadUInt32(),
-                uInMemoryMediaSize = chunk.ReadUInt32(),
-                uSourceBits = chunk.ReadByte(),
+                UInMemoryMediaSize = chunk.ReadUInt32(),
+                USourceBits = chunk.ReadByte(),
             };
         }
     }

--- a/Shared/GameFiles/WWise/Hirc/V122/CAkSwitchCntr_v122.cs
+++ b/Shared/GameFiles/WWise/Hirc/V122/CAkSwitchCntr_v122.cs
@@ -2,27 +2,25 @@
 
 namespace Shared.GameFormats.WWise.Hirc.V122
 {
-
     public class CAkSwitchCntr_v122 : HircItem
     {
         public NodeBaseParams NodeBaseParams { get; set; }
-        public AkGroupType eGroupType { get; set; }
-        public uint ulGroupID { get; set; }   // Enum group name
-        public uint ulDefaultSwitch { get; set; }    // Default value name
-        public byte bIsContinuousValidation { get; set; }
+        public AkGroupType EGroupType { get; set; }
+        public uint UlGroupId { get; set; }
+        public uint UlDefaultSwitch { get; set; }
+        public byte BIsContinuousValidation { get; set; }
         public Children Children { get; set; }
-        public List<CAkSwitchPackage> SwitchList { get; set; } = new List<CAkSwitchPackage>();
-        public List<AkSwitchNodeParams> Parameters { get; set; } = new List<AkSwitchNodeParams>();
+        public List<CAkSwitchPackage> SwitchList { get; set; } = [];
+        public List<AkSwitchNodeParams> Parameters { get; set; } = [];
         public uint GetDirectParentId() => NodeBaseParams.DirectParentId;
-
 
         protected override void CreateSpecificData(ByteChunk chunk)
         {
             NodeBaseParams = NodeBaseParams.Create(chunk);
-            eGroupType = (AkGroupType)chunk.ReadByte();
-            ulGroupID = chunk.ReadUInt32();
-            ulDefaultSwitch = chunk.ReadUInt32();
-            bIsContinuousValidation = chunk.ReadByte();
+            EGroupType = (AkGroupType)chunk.ReadByte();
+            UlGroupId = chunk.ReadUInt32();
+            UlDefaultSwitch = chunk.ReadUInt32();
+            BIsContinuousValidation = chunk.ReadByte();
             Children = Children.Create(chunk);
 
             var switchListCount = chunk.ReadUInt32();
@@ -40,7 +38,7 @@ namespace Shared.GameFormats.WWise.Hirc.V122
 
     public class Children
     {
-        public List<uint> ChildIdList { get; set; } = new List<uint>(); // Probably the name of something, or at least a reference to something interesting
+        public List<uint> ChildIdList { get; set; } = [];
 
         public static Children Create(ByteChunk chunk)
         {
@@ -55,8 +53,8 @@ namespace Shared.GameFormats.WWise.Hirc.V122
 
     public class CAkSwitchPackage
     {
-        public uint SwitchId { get; set; }  // ID/Name of the switch case
-        public List<uint> NodeIdList { get; set; } = new List<uint>(); // Probably the name of something, or at least a reference to something interesting
+        public uint SwitchId { get; set; }
+        public List<uint> NodeIdList { get; set; } = [];
 
         public static CAkSwitchPackage Create(ByteChunk chunk)
         {
@@ -65,7 +63,6 @@ namespace Shared.GameFormats.WWise.Hirc.V122
             var numChildren = chunk.ReadUInt32();
             for (var i = 0; i < numChildren; i++)
                 instance.NodeIdList.Add(chunk.ReadUInt32());
-
             return instance;
         }
     }
@@ -75,7 +72,6 @@ namespace Shared.GameFormats.WWise.Hirc.V122
         public uint NodeId { get; set; }
         public byte BitVector0 { get; set; }
         public byte BitVector1 { get; set; }
-
         public float FadeOutTime { get; set; }
         public float FadeInTime { get; set; }
 
@@ -87,7 +83,6 @@ namespace Shared.GameFormats.WWise.Hirc.V122
             instance.BitVector1 = chunk.ReadByte();
             instance.FadeOutTime = chunk.ReadSingle();
             instance.FadeInTime = chunk.ReadSingle();
-
             return instance;
         }
     }
@@ -95,41 +90,35 @@ namespace Shared.GameFormats.WWise.Hirc.V122
     public class NodeBaseParams
     {
         public NodeInitialFxParams NodeInitialFxParams { get; set; }
-
-
-        public byte bOverrideAttachmentParams { get; set; }
+        public byte BOverrideAttachmentParams { get; set; }
         public uint OverrideBusId { get; set; }
         public uint DirectParentId { get; set; }
-        public byte byBitVector { get; set; }
-
+        public byte ByBitVector { get; set; }
         public NodeInitialParams NodeInitialParams { get; set; }
         public PositioningParams PositioningParams { get; set; }
         public AuxParams AuxParams { get; set; }
         public AdvSettingsParams AdvSettingsParams { get; set; }
         public StateChunk StateChunk { get; set; }
-        public InitialRTPC InitialRTPC { get; set; }
-
-
-        public byte eGroupType { get; set; } // "Switch"
-        public uint ulGroupID { get; set; }     // Enum switch name
-        public uint ulDefaultSwitch { get; set; }   // Enum switch defautl value
-        public byte bIsContinuousValidation { get; set; } // "Switch"
+        public InitialRtpc InitialRtpc { get; set; }
+        public byte EGroupType { get; set; }
+        public uint UlGroupId { get; set; }
+        public uint UlDefaultSwitch { get; set; }
+        public byte BIsContinuousValidation { get; set; }
 
         public static NodeBaseParams Create(ByteChunk chunk)
         {
             var node = new NodeBaseParams();
             node.NodeInitialFxParams = NodeInitialFxParams.Create(chunk);
-            node.bOverrideAttachmentParams = chunk.ReadByte();
+            node.BOverrideAttachmentParams = chunk.ReadByte();
             node.OverrideBusId = chunk.ReadUInt32();
             node.DirectParentId = chunk.ReadUInt32();
-            node.byBitVector = chunk.ReadByte();
+            node.ByBitVector = chunk.ReadByte();
             node.NodeInitialParams = NodeInitialParams.Create(chunk);
             node.PositioningParams = PositioningParams.Create(chunk);
             node.AuxParams = AuxParams.Create(chunk);
             node.AdvSettingsParams = AdvSettingsParams.Create(chunk);
             node.StateChunk = StateChunk.Create(chunk);
-            node.InitialRTPC = InitialRTPC.Create(chunk);
-
+            node.InitialRtpc = InitialRtpc.Create(chunk);
             return node;
         }
     }
@@ -157,7 +146,7 @@ namespace Shared.GameFormats.WWise.Hirc.V122
             public float Value { get; set; }
         }
 
-        public List<AkPropBundleInstance> Values = new List<AkPropBundleInstance>();
+        public List<AkPropBundleInstance> _values = [];
 
         public static AkPropBundle Create(ByteChunk chunk)
         {
@@ -165,10 +154,10 @@ namespace Shared.GameFormats.WWise.Hirc.V122
             var propsCount = chunk.ReadByte();
 
             for (byte i = 0; i < propsCount; i++)
-                output.Values.Add(new AkPropBundleInstance() { Type = (AkPropBundleType)chunk.ReadByte() });
+                output._values.Add(new AkPropBundleInstance() { Type = (AkPropBundleType)chunk.ReadByte() });
 
             for (byte i = 0; i < propsCount; i++)
-                output.Values[i].Value = chunk.ReadSingle();
+                output._values[i].Value = chunk.ReadSingle();
 
             return output;
         }
@@ -183,7 +172,7 @@ namespace Shared.GameFormats.WWise.Hirc.V122
             public float Max { get; set; }
         }
 
-        public List<AkPropBundleInstance> Values = new List<AkPropBundleInstance>();
+        public List<AkPropBundleInstance> _values = [];
 
         public static AkPropBundleMinMax Create(ByteChunk chunk)
         {
@@ -191,12 +180,12 @@ namespace Shared.GameFormats.WWise.Hirc.V122
             var propsCount = chunk.ReadByte();
 
             for (byte i = 0; i < propsCount; i++)
-                output.Values.Add(new AkPropBundleInstance() { Type = (AkPropBundleType)chunk.ReadByte() });
+                output._values.Add(new AkPropBundleInstance() { Type = (AkPropBundleType)chunk.ReadByte() });
 
             for (byte i = 0; i < propsCount; i++)
             {
-                output.Values[i].Min = chunk.ReadSingle();
-                output.Values[i].Max = chunk.ReadSingle();
+                output._values[i].Min = chunk.ReadSingle();
+                output._values[i].Max = chunk.ReadSingle();
             }
 
             return output;
@@ -205,20 +194,20 @@ namespace Shared.GameFormats.WWise.Hirc.V122
 
     public class NodeInitialFxParams
     {
-        public byte bIsOverrideParentFX { get; set; }
+        public byte BIsOverrideParentFX { get; set; }
 
-        public byte bitsFXBypass { get; set; }
-        public List<FXChunk> FxList { get; set; } = new List<FXChunk>();
+        public byte BitsFxBypass { get; set; }
+        public List<FXChunk> FxList { get; set; } = [];
 
         public static NodeInitialFxParams Create(ByteChunk chunk)
         {
             var instance = new NodeInitialFxParams();
-            instance.bIsOverrideParentFX = chunk.ReadByte();
+            instance.BIsOverrideParentFX = chunk.ReadByte();
             var uNumFx = chunk.ReadByte();
 
             if (uNumFx != 0)
             {
-                instance.bitsFXBypass = chunk.ReadByte();
+                instance.BitsFxBypass = chunk.ReadByte();
                 for (var i = 0; i < uNumFx; i++)
                     instance.FxList.Add(FXChunk.Create(chunk));
             }
@@ -229,51 +218,49 @@ namespace Shared.GameFormats.WWise.Hirc.V122
 
     public class FXChunk
     {
-        public byte uFXIndex { get; set; }
-        public uint fxID { get; set; }
-        public byte bIsShareSet { get; set; }
-        public byte bIsRendered { get; set; }
+        public byte UFXIndex { get; set; }
+        public uint FxId { get; set; }
+        public byte BIsShareSet { get; set; }
+        public byte BIsRendered { get; set; }
 
         public static FXChunk Create(ByteChunk chunk)
         {
             var instance = new FXChunk();
-            instance.uFXIndex = chunk.ReadByte();
-            instance.fxID = chunk.ReadUInt32();
-            instance.bIsShareSet = chunk.ReadByte();
-            instance.bIsRendered = chunk.ReadByte();
+            instance.UFXIndex = chunk.ReadByte();
+            instance.FxId = chunk.ReadUInt32();
+            instance.BIsShareSet = chunk.ReadByte();
+            instance.BIsRendered = chunk.ReadByte();
             return instance;
         }
     }
 
-
     public class PositioningParams
     {
-        public byte uByVector { get; set; }
-        public byte uBits3d { get; set; }
-        public uint uAttenuationID { get; set; }
-
-        public byte ePathMode { get; set; }
+        public byte UByVector { get; set; }
+        public byte UBits3d { get; set; }
+        public uint UAttenuationId { get; set; }
+        public byte EPathMode { get; set; }
         public float TransitionTime { get; set; }
-        public List<AkPathVertex> VertexList { get; set; } = new List<AkPathVertex>();
-        public List<AkPathListItemOffset> PlayListItems { get; set; } = new List<AkPathListItemOffset>();
-        public List<Ak3DAutomationParams> Params { get; set; } = new List<Ak3DAutomationParams>();
+        public List<AkPathVertex> VertexList { get; set; } = [];
+        public List<AkPathListItemOffset> PlayListItems { get; set; } = [];
+        public List<Ak3DAutomationParams> Params { get; set; } = [];
 
         public static PositioningParams Create(ByteChunk chunk)
         {
             var instance = new PositioningParams();
-            instance.uByVector = chunk.ReadByte();
+            instance.UByVector = chunk.ReadByte();
 
-            var bPositioningInfoOverrideParent = (instance.uByVector >> 0 & 1) == 1;
-            var cbIs3DPositioningAvailable = (instance.uByVector >> 3 & 1) == 1;
+            var bPositioningInfoOverrideParent = (instance.UByVector >> 0 & 1) == 1;
+            var cbIs3DPositioningAvailable = (instance.UByVector >> 3 & 1) == 1;
 
             if (bPositioningInfoOverrideParent && cbIs3DPositioningAvailable)
             {
-                instance.uBits3d = chunk.ReadByte();
-                instance.uAttenuationID = chunk.ReadUInt32();
+                instance.UBits3d = chunk.ReadByte();
+                instance.UAttenuationId = chunk.ReadUInt32();
 
-                if ((instance.uBits3d >> 0 & 1) == 0)
+                if ((instance.UBits3d >> 0 & 1) == 0)
                 {
-                    instance.ePathMode = chunk.ReadByte();
+                    instance.EPathMode = chunk.ReadByte();
                     instance.TransitionTime = chunk.ReadSingle();
 
                     var numVertexes = chunk.ReadUInt32();
@@ -291,7 +278,6 @@ namespace Shared.GameFormats.WWise.Hirc.V122
                         instance.Params.Add(Ak3DAutomationParams.Create(chunk));
                 }
             }
-
 
             return instance;
         }
@@ -311,22 +297,20 @@ namespace Shared.GameFormats.WWise.Hirc.V122
             instance.Y = chunk.ReadSingle();
             instance.Z = chunk.ReadSingle();
             instance.Duration = chunk.ReadInt32();
-
             return instance;
         }
     }
 
     public class AkPathListItemOffset
     {
-        public uint ulVerticesOffset { get; set; }
-        public uint iNumVertices { get; set; }
+        public uint UlVerticesOffset { get; set; }
+        public uint INumVertices { get; set; }
 
         public static AkPathListItemOffset Create(ByteChunk chunk)
         {
             var instance = new AkPathListItemOffset();
-            instance.ulVerticesOffset = chunk.ReadUInt32();
-            instance.iNumVertices = chunk.ReadUInt32();
-
+            instance.UlVerticesOffset = chunk.ReadUInt32();
+            instance.INumVertices = chunk.ReadUInt32();
             return instance;
         }
     }
@@ -350,50 +334,46 @@ namespace Shared.GameFormats.WWise.Hirc.V122
 
     public class AuxParams
     {
-        public byte byBitVector { get; set; }
-        public uint auxID0 { get; set; }
-        public uint auxID1 { get; set; }
-        public uint auxID2 { get; set; }
-        public uint auxID3 { get; set; }
+        public byte ByBitVector { get; set; }
+        public uint AuxId0 { get; set; }
+        public uint AuxId1 { get; set; }
+        public uint AuxId2 { get; set; }
+        public uint AuxId3 { get; set; }
 
         public static AuxParams Create(ByteChunk chunk)
         {
             var instance = new AuxParams();
-            instance.byBitVector = chunk.ReadByte();
+            instance.ByBitVector = chunk.ReadByte();
 
-            if ((instance.byBitVector >> 3 & 1) == 1)
+            if ((instance.ByBitVector >> 3 & 1) == 1)
             {
-                instance.auxID0 = chunk.ReadUInt32();
-                instance.auxID1 = chunk.ReadUInt32();
-                instance.auxID2 = chunk.ReadUInt32();
-                instance.auxID3 = chunk.ReadUInt32();
+                instance.AuxId0 = chunk.ReadUInt32();
+                instance.AuxId1 = chunk.ReadUInt32();
+                instance.AuxId2 = chunk.ReadUInt32();
+                instance.AuxId3 = chunk.ReadUInt32();
             }
 
             return instance;
         }
     }
 
-
     public class AdvSettingsParams
     {
-        public byte byBitVector { get; set; }
-        public byte eVirtualQueueBehavior { get; set; }
-        public ushort u16MaxNumInstance { get; set; }
-        public byte eBelowThresholdBehavior { get; set; }
-        public byte byBitVector2 { get; set; }
-
-
+        public byte ByBitVector { get; set; }
+        public byte EVirtualQueueBehavior { get; set; }
+        public ushort U16MaxNumInstance { get; set; }
+        public byte EBelowThresholdBehavior { get; set; }
+        public byte ByBitVector2 { get; set; }
 
         public static AdvSettingsParams Create(ByteChunk chunk)
         {
-            return new AdvSettingsParams() { byBitVector = chunk.ReadByte(), eVirtualQueueBehavior = chunk.ReadByte(), u16MaxNumInstance = chunk.ReadUShort(), eBelowThresholdBehavior = chunk.ReadByte(), byBitVector2 = chunk.ReadByte() };
+            return new AdvSettingsParams() { ByBitVector = chunk.ReadByte(), EVirtualQueueBehavior = chunk.ReadByte(), U16MaxNumInstance = chunk.ReadUShort(), EBelowThresholdBehavior = chunk.ReadByte(), ByBitVector2 = chunk.ReadByte() };
         }
     }
 
-
     public class StateChunk
     {
-        public List<AkStateGroupChunk> StateChunks { get; set; } = new List<AkStateGroupChunk>();
+        public List<AkStateGroupChunk> StateChunks { get; set; } = [];
 
         public static StateChunk Create(ByteChunk chunk)
         {
@@ -405,18 +385,17 @@ namespace Shared.GameFormats.WWise.Hirc.V122
         }
     }
 
-
     public class AkStateGroupChunk
     {
-        public uint ulStateGroupID { get; set; }
-        public byte eStateSyncType { get; set; }
-        public List<AkState> States { get; set; } = new List<AkState>();
+        public uint UlStateGroupId { get; set; }
+        public byte EStateSyncType { get; set; }
+        public List<AkState> States { get; set; } = [];
 
         public static AkStateGroupChunk Create(ByteChunk chunk)
         {
             var instance = new AkStateGroupChunk();
-            instance.ulStateGroupID = chunk.ReadUInt32();
-            instance.eStateSyncType = chunk.ReadByte();
+            instance.UlStateGroupId = chunk.ReadUInt32();
+            instance.EStateSyncType = chunk.ReadByte();
 
             var count = chunk.ReadUShort();
             for (var i = 0; i < count; i++)
@@ -428,75 +407,72 @@ namespace Shared.GameFormats.WWise.Hirc.V122
 
     public class AkState
     {
-        public uint ulStateID { get; set; }
-        public uint ulStateInstanceID { get; set; }
+        public uint UlStateId { get; set; }
+        public uint UlStateInstanceId { get; set; }
         public static AkState Create(ByteChunk chunk)
         {
             var instance = new AkState();
-            instance.ulStateID = chunk.ReadUInt32();
-            instance.ulStateInstanceID = chunk.ReadUInt32();
+            instance.UlStateId = chunk.ReadUInt32();
+            instance.UlStateInstanceId = chunk.ReadUInt32();
             return instance;
         }
     }
 
-
-    public class InitialRTPC
+    public class InitialRtpc
     {
-        public List<RTPC> RTPCList { get; set; } = new List<RTPC>();
+        public List<Rtpc> RtpcList { get; set; } = [];
 
-        public static InitialRTPC Create(ByteChunk chunk)
+        public static InitialRtpc Create(ByteChunk chunk)
         {
-            var instance = new InitialRTPC();
+            var instance = new InitialRtpc();
             var count = chunk.ReadUShort();
             for (var i = 0; i < count; i++)
-                instance.RTPCList.Add(RTPC.Create(chunk));
-
+                instance.RtpcList.Add(Rtpc.Create(chunk));
             return instance;
         }
     }
 
-    public class RTPC
+    public class Rtpc
     {
-        public uint RTPCID { get; set; }
-        public byte rtpcType { get; set; }
-        public byte rtpcAccum { get; set; }
-        public byte ParamID { get; set; }
-        public uint rtpcCurveID { get; set; }
-        public byte eScaling { get; set; }
-        public List<AkRTPCGraphPoint> pRTPCMgr { get; set; } = new List<AkRTPCGraphPoint>();
+        public uint RtpcId { get; set; }
+        public byte RtpcType { get; set; }
+        public byte RtpcAccum { get; set; }
+        public byte ParamId { get; set; }
+        public uint RtpcCurveId { get; set; }
+        public byte EScaling { get; set; }
+        public List<AkRtpcGraphPoint> PRtpcMgr { get; set; } = [];
 
-        public static RTPC Create(ByteChunk chunk)
+        public static Rtpc Create(ByteChunk chunk)
         {
-            var instance = new RTPC();
-            instance.RTPCID = chunk.ReadUInt32();
-            instance.rtpcType = chunk.ReadByte();
-            instance.rtpcAccum = chunk.ReadByte();
-            instance.ParamID = chunk.ReadByte();
-            instance.rtpcCurveID = chunk.ReadUInt32();
-            instance.eScaling = chunk.ReadByte();
+            var instance = new Rtpc();
+            instance.RtpcId = chunk.ReadUInt32();
+            instance.RtpcType = chunk.ReadByte();
+            instance.RtpcAccum = chunk.ReadByte();
+            instance.ParamId = chunk.ReadByte();
+            instance.RtpcCurveId = chunk.ReadUInt32();
+            instance.EScaling = chunk.ReadByte();
 
             var count = chunk.ReadUShort();
             for (var i = 0; i < count; i++)
-                instance.pRTPCMgr.Add(AkRTPCGraphPoint.Create(chunk));
+                instance.PRtpcMgr.Add(AkRtpcGraphPoint.Create(chunk));
 
             return instance;
         }
     }
 
-    public class AkRTPCGraphPoint
+    public class AkRtpcGraphPoint
     {
         public float From { get; set; }
         public float To { get; set; }
         public uint Interp { get; set; }
 
-        public static AkRTPCGraphPoint Create(ByteChunk chunk)
+        public static AkRtpcGraphPoint Create(ByteChunk chunk)
         {
-            var instance = new AkRTPCGraphPoint();
+            var instance = new AkRtpcGraphPoint();
             instance.From = chunk.ReadSingle();
             instance.To = chunk.ReadSingle();
             instance.Interp = chunk.ReadUInt32();
             return instance;
         }
     }
-
 }

--- a/Shared/GameFiles/WWise/Hirc/V136/CAkAction_v136.cs
+++ b/Shared/GameFiles/WWise/Hirc/V136/CAkAction_v136.cs
@@ -5,9 +5,8 @@ namespace Shared.GameFormats.WWise.Hirc.V136
     public class CAkAction_v136 : HircItem, ICAkAction
     {
         public ActionType ActionType { get; set; }
-        public uint idExt { get; set; }
-        public byte idExt_4 { get; set; }
-
+        public uint IdExt { get; set; }
+        public byte IdExt4 { get; set; }
         public AkPropBundle AkPropBundle0 { get; set; } = new AkPropBundle();
         public AkPropBundle AkPropBundle1 { get; set; } = new AkPropBundle();
         public AkPlayActionParams AkPlayActionParams { get; set; } = new AkPlayActionParams();
@@ -16,8 +15,8 @@ namespace Shared.GameFormats.WWise.Hirc.V136
         protected override void CreateSpecificData(ByteChunk chunk)
         {
             ActionType = (ActionType)chunk.ReadUShort();
-            idExt = chunk.ReadUInt32();
-            idExt_4 = chunk.ReadByte();
+            IdExt = chunk.ReadUInt32();
+            IdExt4 = chunk.ReadByte();
 
             if (ActionType == ActionType.Play)
             {
@@ -40,8 +39,8 @@ namespace Shared.GameFormats.WWise.Hirc.V136
 
             using var memStream = WriteHeader();
             memStream.Write(ByteParsers.UShort.EncodeValue((ushort)ActionType, out _));
-            memStream.Write(ByteParsers.UInt32.EncodeValue(idExt, out _));
-            memStream.Write(ByteParsers.Byte.EncodeValue(idExt_4, out _));
+            memStream.Write(ByteParsers.UInt32.EncodeValue(IdExt, out _));
+            memStream.Write(ByteParsers.Byte.EncodeValue(IdExt4, out _));
             memStream.Write(AkPropBundle0.GetAsBytes());
             memStream.Write(AkPropBundle1.GetAsBytes());
             memStream.Write(AkPlayActionParams.GetAsBytes());
@@ -59,29 +58,26 @@ namespace Shared.GameFormats.WWise.Hirc.V136
         {
             Size = HircHeaderSize + 2 + 4 + 1 + AkPropBundle0.GetSize() + AkPropBundle1.GetSize() + AkPlayActionParams.ComputeSize();
         }
-
-
         public ActionType GetActionType() => ActionType;
-        public uint GetChildId() => idExt;
-
-        public uint GetStateGroupId() => AkSetStateParams.ulStateGroupID;
+        public uint GetChildId() => IdExt;
+        public uint GetStateGroupId() => AkSetStateParams.UlStateGroupId;
     }
 
     public class AkPlayActionParams
     {
-        public byte byBitVector { get; set; }
-        public uint bankId { get; set; }
+        public byte ByBitVector { get; set; }
+        public uint BankId { get; set; }
 
         public static AkPlayActionParams Create(ByteChunk chunk)
         {
             return new AkPlayActionParams()
             {
-                byBitVector = chunk.ReadByte(),
-                bankId = chunk.ReadUInt32(),
+                ByBitVector = chunk.ReadByte(),
+                BankId = chunk.ReadUInt32(),
             };
         }
 
-        internal uint ComputeSize()
+        internal static uint ComputeSize()
         {
             return 5;
         }
@@ -89,8 +85,8 @@ namespace Shared.GameFormats.WWise.Hirc.V136
         public byte[] GetAsBytes()
         {
             var allbytes = new List<byte>();
-            allbytes.AddRange(ByteParsers.Byte.EncodeValue(byBitVector, out _));
-            allbytes.AddRange(ByteParsers.UInt32.EncodeValue(bankId, out _));
+            allbytes.AddRange(ByteParsers.Byte.EncodeValue(ByBitVector, out _));
+            allbytes.AddRange(ByteParsers.UInt32.EncodeValue(BankId, out _));
             return allbytes.ToArray();
         }
     }
@@ -98,19 +94,19 @@ namespace Shared.GameFormats.WWise.Hirc.V136
 
     public class AkSetStateParams
     {
-        public uint ulStateGroupID { get; set; }
-        public uint ulTargetStateID { get; set; }
+        public uint UlStateGroupId { get; set; }
+        public uint UlTargetStateId { get; set; }
 
         public static AkSetStateParams Create(ByteChunk chunk)
         {
             return new AkSetStateParams()
             {
-                ulStateGroupID = chunk.ReadUInt32(),
-                ulTargetStateID = chunk.ReadUInt32(),
+                UlStateGroupId = chunk.ReadUInt32(),
+                UlTargetStateId = chunk.ReadUInt32(),
             };
         }
 
-        internal uint ComputeSize()
+        internal static uint ComputeSize()
         {
             return 8;
         }
@@ -118,8 +114,8 @@ namespace Shared.GameFormats.WWise.Hirc.V136
         public byte[] GetAsBytes()
         {
             var allbytes = new List<byte>();
-            allbytes.AddRange(ByteParsers.UInt32.EncodeValue(ulStateGroupID, out _));
-            allbytes.AddRange(ByteParsers.UInt32.EncodeValue(ulTargetStateID, out _));
+            allbytes.AddRange(ByteParsers.UInt32.EncodeValue(UlStateGroupId, out _));
+            allbytes.AddRange(ByteParsers.UInt32.EncodeValue(UlTargetStateId, out _));
             return allbytes.ToArray();
         }
     }

--- a/Shared/GameFiles/WWise/Hirc/V136/CAkActorMixer_v136.cs
+++ b/Shared/GameFiles/WWise/Hirc/V136/CAkActorMixer_v136.cs
@@ -8,7 +8,6 @@ namespace Shared.GameFormats.WWise.Hirc.V136
         public Children Children { get; set; }
         public uint GetDirectParentId() => NodeBaseParams.DirectParentId;
 
-
         protected override void CreateSpecificData(ByteChunk chunk)
         {
             NodeBaseParams = NodeBaseParams.Create(chunk);
@@ -37,4 +36,3 @@ namespace Shared.GameFormats.WWise.Hirc.V136
         public List<uint> GetChildren() => Children.ChildIdList;
     }
 }
-

--- a/Shared/GameFiles/WWise/Hirc/V136/CAkBus_v136.cs
+++ b/Shared/GameFiles/WWise/Hirc/V136/CAkBus_v136.cs
@@ -5,35 +5,28 @@ namespace Shared.GameFormats.WWise.Hirc.V136
     public class CAkBus_v136 : HircItem
     {
         public uint OverrideBusId { get; set; }
-        public uint idDeviceShareset { get; set; }
+        public uint IdDeviceShareset { get; set; }
         public BusInitialParams BusInitialParams { get; set; }
-
         public float RecoveryTime { get; set; }
-        public float fMaxDuckVolume { get; set; }
+        public float FMaxDuckVolume { get; set; }
         public DuckList DuckList { get; set; }
-
         public BusInitialFxParams BusInitialFxParams { get; set; }
-        public byte bOverrideAttachmentParams { get; set; }
-        public InitialRTPC InitialRTPC { get; set; }
+        public byte BOverrideAttachmentParams { get; set; }
+        public InitialRtpc InitialRtpc { get; set; }
         public StateChunk StateChunk { get; set; }
 
         protected override void CreateSpecificData(ByteChunk chunk)
         {
-            if (Id == 2665947595)
-            {
-
-            }
-
             OverrideBusId = chunk.ReadUInt32();
             if (OverrideBusId == 0)
-                idDeviceShareset = chunk.ReadUInt32();
+                IdDeviceShareset = chunk.ReadUInt32();
             BusInitialParams = BusInitialParams.Create(chunk);
             RecoveryTime = chunk.ReadSingle();
-            fMaxDuckVolume = chunk.ReadSingle();
+            FMaxDuckVolume = chunk.ReadSingle();
             DuckList = DuckList.Create(chunk);
             BusInitialFxParams = BusInitialFxParams.Create(chunk);
-            bOverrideAttachmentParams = chunk.ReadByte();
-            InitialRTPC = InitialRTPC.Create(chunk);
+            BOverrideAttachmentParams = chunk.ReadByte();
+            InitialRtpc = InitialRtpc.Create(chunk);
             StateChunk = StateChunk.Create(chunk);
         }
 
@@ -43,26 +36,26 @@ namespace Shared.GameFormats.WWise.Hirc.V136
 
     public class DuckList
     {
-        public uint ulDucks { get; set; }
-        public List<AkDuckInfo> Ducks { get; set; } = new List<AkDuckInfo>();
+        public uint UlDucks { get; set; }
+        public List<AkDuckInfo> Ducks { get; set; } = [];
 
         public class AkDuckInfo
         {
-            public uint BusID { get; set; }
+            public uint BusId { get; set; }
             public float DuckVolume { get; set; }
             public float FadeOutTime { get; set; }
             public float FadeInTime { get; set; }
-            public byte eFadeCurve { get; set; }
+            public byte EFadeCurve { get; set; }
             public byte TargetProp { get; set; }
 
             public static AkDuckInfo Create(ByteChunk chunk)
             {
                 var instance = new AkDuckInfo();
-                instance.BusID = chunk.ReadUInt32();
+                instance.BusId = chunk.ReadUInt32();
                 instance.DuckVolume = chunk.ReadSingle();
                 instance.FadeOutTime = chunk.ReadSingle();
                 instance.FadeInTime = chunk.ReadSingle();
-                instance.eFadeCurve = chunk.ReadByte();
+                instance.EFadeCurve = chunk.ReadByte();
                 instance.TargetProp = chunk.ReadByte();
                 return instance;
             }
@@ -72,34 +65,32 @@ namespace Shared.GameFormats.WWise.Hirc.V136
         public static DuckList Create(ByteChunk chunk)
         {
             var instance = new DuckList();
-            instance.ulDucks = chunk.ReadUInt32();
-            for (uint i = 0; i < instance.ulDucks; i++)
+            instance.UlDucks = chunk.ReadUInt32();
+            for (uint i = 0; i < instance.UlDucks; i++)
                 instance.Ducks.Add(AkDuckInfo.Create(chunk));
-
-
             return instance;
         }
     }
 
     public class BusInitialFxParams
     {
-        public byte uNumFx { get; set; }
-        public byte bitsFXBypass { get; set; }
-        public List<FXChunk> FXChunkList { get; set; } = new List<FXChunk>();
-        public uint fxID_0 { get; set; }
-        public byte bIsShareSet_0 { get; set; }
+        public byte UNumFx { get; set; }
+        public byte BitsFXBypass { get; set; }
+        public List<FXChunk> FXChunkList { get; set; } = [];
+        public uint FxId0 { get; set; }
+        public byte BIsShareSet0 { get; set; }
         public static BusInitialFxParams Create(ByteChunk chunk)
         {
             var instance = new BusInitialFxParams();
-            instance.uNumFx = chunk.ReadByte();
-            if (instance.uNumFx != 0)
-                instance.bitsFXBypass = chunk.ReadByte();
+            instance.UNumFx = chunk.ReadByte();
+            if (instance.UNumFx != 0)
+                instance.BitsFXBypass = chunk.ReadByte();
 
-            for (uint i = 0; i < instance.uNumFx; i++)
+            for (uint i = 0; i < instance.UNumFx; i++)
                 instance.FXChunkList.Add(FXChunk.Create(chunk));
 
-            instance.fxID_0 = chunk.ReadUInt32();
-            instance.bIsShareSet_0 = chunk.ReadByte();
+            instance.FxId0 = chunk.ReadUInt32();
+            instance.BIsShareSet0 = chunk.ReadByte();
 
             return instance;
         }
@@ -111,23 +102,21 @@ namespace Shared.GameFormats.WWise.Hirc.V136
         public PositioningParams PositioningParams { get; set; }
         public AuxParams AuxParams { get; set; }
         //public byte byBitVector0 { get; set; }
-        public byte byBitVector1 { get; set; }
-        public ushort u16MaxNumInstance { get; set; }
-        public uint uChannelConfig { get; set; }
-        public byte byBitVector2 { get; set; }
+        public byte ByBitVector1 { get; set; }
+        public ushort U16MaxNumInstance { get; set; }
+        public uint UChannelConfig { get; set; }
+        public byte ByBitVector2 { get; set; }
         public static BusInitialParams Create(ByteChunk chunk)
         {
             var instance = new BusInitialParams();
             instance.AkPropBundle = AkPropBundle.Create(chunk);
             instance.PositioningParams = PositioningParams.Create(chunk);
             instance.AuxParams = AuxParams.Create(chunk);
-
             //instance.byBitVector0 = chunk.ReadByte();
-            instance.byBitVector1 = chunk.ReadByte();
-            instance.u16MaxNumInstance = chunk.ReadUShort();
-            instance.uChannelConfig = chunk.ReadUInt32();
-            instance.byBitVector2 = chunk.ReadByte();
-
+            instance.ByBitVector1 = chunk.ReadByte();
+            instance.U16MaxNumInstance = chunk.ReadUShort();
+            instance.UChannelConfig = chunk.ReadUInt32();
+            instance.ByBitVector2 = chunk.ReadByte();
             return instance;
         }
     }

--- a/Shared/GameFiles/WWise/Hirc/V136/CAkDialogueEvent_v136.cs
+++ b/Shared/GameFiles/WWise/Hirc/V136/CAkDialogueEvent_v136.cs
@@ -7,11 +7,11 @@ namespace Shared.GameFormats.WWise.Hirc.V136
 {
     public class CAkDialogueEvent_v136 : HircItem, ICADialogEvent
     {
-        public byte uProbability { get; set; }
-        public uint uTreeDepth { get; set; }
+        public byte UProbability { get; set; }
+        public uint UTreeDepth { get; set; }
         public ArgumentList ArgumentList { get; set; }
-        public uint uTreeDataSize { get; set; }
-        public byte uMode { get; set; }
+        public uint UTreeDataSize { get; set; }
+        public byte UMode { get; set; }
         public AkDecisionTree AkDecisionTree { get; set; }
         public List<Argument> CustomArgumentList { get; set; }
         public List<BinaryNode> CustomAkDecisionTree { get; set; }
@@ -20,13 +20,13 @@ namespace Shared.GameFormats.WWise.Hirc.V136
 
         protected override void CreateSpecificData(ByteChunk chunk)
         {
-            uProbability = chunk.ReadByte();
-            uTreeDepth = chunk.ReadUInt32();
-            ArgumentList = new ArgumentList(chunk, uTreeDepth);
-            uTreeDataSize = chunk.ReadUInt32();
-            uMode = chunk.ReadByte();
+            UProbability = chunk.ReadByte();
+            UTreeDepth = chunk.ReadUInt32();
+            ArgumentList = new ArgumentList(chunk, UTreeDepth);
+            UTreeDataSize = chunk.ReadUInt32();
+            UMode = chunk.ReadByte();
 
-            AkDecisionTree = new AkDecisionTree(chunk, uTreeDepth, uTreeDataSize);
+            AkDecisionTree = new AkDecisionTree(chunk, UTreeDepth, UTreeDataSize);
 
             AkPropBundle0 = chunk.ReadByte();
             AkPropBundle1 = chunk.ReadByte();
@@ -34,16 +34,17 @@ namespace Shared.GameFormats.WWise.Hirc.V136
 
         public override void UpdateSize()
         {
-            Size = HircHeaderSize + 1 + 4 + (uint)CustomArgumentList.Count * 5 + 4 + 1 + uTreeDataSize + 1 + 1;
+            Size = HircHeaderSize + 1 + 4 + (uint)CustomArgumentList.Count * 5 + 4 + 1 + UTreeDataSize + 1 + 1;
         }
+
         public override byte[] GetAsByteArray()
         {
             using var memStream = WriteHeader();
-            memStream.Write(ByteParsers.Byte.EncodeValue(uProbability, out _));
-            memStream.Write(ByteParsers.UInt32.EncodeValue(uTreeDepth, out _));
+            memStream.Write(ByteParsers.Byte.EncodeValue(UProbability, out _));
+            memStream.Write(ByteParsers.UInt32.EncodeValue(UTreeDepth, out _));
             memStream.Write(GetCustomArgumentsAsBytes(CustomArgumentList));
-            memStream.Write(ByteParsers.UInt32.EncodeValue(uTreeDataSize, out _));
-            memStream.Write(ByteParsers.Byte.EncodeValue(uMode, out _));
+            memStream.Write(ByteParsers.UInt32.EncodeValue(UTreeDataSize, out _));
+            memStream.Write(ByteParsers.Byte.EncodeValue(UMode, out _));
 
             memStream.Write(GetAsBytes(CustomAkDecisionTree));
 

--- a/Shared/GameFiles/WWise/Hirc/V136/CAkEvent_v136.cs
+++ b/Shared/GameFiles/WWise/Hirc/V136/CAkEvent_v136.cs
@@ -9,7 +9,7 @@ namespace Shared.GameFormats.WWise.Hirc.V136
             public uint ActionId { get; set; }
         }
 
-        public List<Action> Actions { get; set; } = new List<Action>();
+        public List<Action> Actions { get; set; } = [];
 
         protected override void CreateSpecificData(ByteChunk chunk)
         {
@@ -41,7 +41,5 @@ namespace Shared.GameFormats.WWise.Hirc.V136
         {
             Size = (uint)(HircHeaderSize + 1 + 4 * Actions.Count);
         }
-
-
     }
 }

--- a/Shared/GameFiles/WWise/Hirc/V136/CAkFxCustom_v136.cs
+++ b/Shared/GameFiles/WWise/Hirc/V136/CAkFxCustom_v136.cs
@@ -4,32 +4,31 @@ namespace Shared.GameFormats.WWise.Hirc.V136
 {
     public class CAkFxCustom_v136 : HircItem
     {
-        public uint plugin_id { get; set; }
+        public uint PluginId { get; set; }
         public AkPluginParam AkPluginParam { get; set; }
-        public List<AkMediaMap> mediaList { get; set; } = new List<AkMediaMap>();
-        public InitialRTPC InitialRTPC { get; set; }
+        public List<AkMediaMap> MediaList { get; set; } = [];
+        public InitialRtpc InitialRtpc { get; set; }
         public StateChunk StateChunk { get; set; }
-        public List<PluginPropertyValue> propertyValuesList { get; set; } = new List<PluginPropertyValue>();
+        public List<PluginPropertyValue> PropertyValuesList { get; set; } = [];
 
         protected override void CreateSpecificData(ByteChunk chunk)
         {
             //contains the plugin type and company id (CA doesn't have one apparently)
-            plugin_id = chunk.ReadUInt32();
+            PluginId = chunk.ReadUInt32();
 
             var uSize = chunk.ReadUInt32();
-            AkPluginParam = AkPluginParam.Create(chunk, plugin_id, uSize);
+            AkPluginParam = AkPluginParam.Create(chunk, PluginId, uSize);
 
             var uNumBankData = chunk.ReadByte();
             for (var i = 0; i < uNumBankData; i++)
-                mediaList.Add(AkMediaMap.Create(chunk));
+                MediaList.Add(AkMediaMap.Create(chunk));
 
-            InitialRTPC = InitialRTPC.Create(chunk);
+            InitialRtpc = InitialRtpc.Create(chunk);
             StateChunk = StateChunk.Create(chunk);
 
             var numValues = chunk.ReadShort();
             for (var i = 0; i < numValues; i++)
-                propertyValuesList.Add(PluginPropertyValue.Create(chunk));
-
+                PropertyValuesList.Add(PluginPropertyValue.Create(chunk));
         }
 
         public override void UpdateSize() => throw new NotImplementedException();
@@ -38,57 +37,53 @@ namespace Shared.GameFormats.WWise.Hirc.V136
 
     public class AkMediaMap
     {
-        public byte index { get; set; }
-        public uint sourceId { get; set; }
+        public byte Index { get; set; }
+        public uint SourceId { get; set; }
 
         public static AkMediaMap Create(ByteChunk chunk)
         {
             var instance = new AkMediaMap();
-
-            instance.index = chunk.ReadByte();
-            instance.sourceId = chunk.ReadUInt32();
-
+            instance.Index = chunk.ReadByte();
+            instance.SourceId = chunk.ReadUInt32();
             return instance;
         }
     }
 
     public class PluginPropertyValue
     {
-        public uint propertyId { get; set; }
-        public byte rtpcAccum { get; set; }
-        public float fValue { get; set; }
+        public uint PropertyId { get; set; }
+        public byte RtpcAccum { get; set; }
+        public float FValue { get; set; }
 
         public static PluginPropertyValue Create(ByteChunk chunk)
         {
             var instance = new PluginPropertyValue();
-
-            instance.propertyId = chunk.ReadUInt32();
-            instance.rtpcAccum = chunk.ReadByte();
-            instance.fValue = chunk.ReadSingle();
-
+            instance.PropertyId = chunk.ReadUInt32();
+            instance.RtpcAccum = chunk.ReadByte();
+            instance.FValue = chunk.ReadSingle();
             return instance;
         }
     }
 
     public class CAkFxSrcSilenceParams : AkPluginParam
     {
-        public float fDuration { get; set; }
-        public float fRandomizedLengthMinus { get; set; }
-        public float fRandomizedLengthPlus { get; set; }
+        public float FDuration { get; set; }
+        public float FRandomizedLengthMinus { get; set; }
+        public float FRandomizedLengthPlus { get; set; }
 
         public static CAkFxSrcSilenceParams Create(ByteChunk chunk, uint uSize)
         {
             var instance = new CAkFxSrcSilenceParams();
-            instance.fDuration = chunk.ReadSingle();
-            instance.fRandomizedLengthMinus = chunk.ReadSingle();
-            instance.fRandomizedLengthPlus = chunk.ReadSingle();
+            instance.FDuration = chunk.ReadSingle();
+            instance.FRandomizedLengthMinus = chunk.ReadSingle();
+            instance.FRandomizedLengthPlus = chunk.ReadSingle();
             return instance;
         }
     }
 
     public class AkPluginParam
     {
-        public List<byte> pParamBlock { get; set; } = new List<byte>();
+        public List<byte> PParamBlock { get; set; } = [];
         //used for default case, "gap" of bytes
 
         public static AkPluginParam Create(ByteChunk chunk, uint plugin_id, uint uSize)
@@ -118,7 +113,7 @@ namespace Shared.GameFormats.WWise.Hirc.V136
                     //Default "gap"
                     var instance = new AkPluginParam();
                     for (var i = 0; i < uSize; i++)
-                        instance.pParamBlock.Add(chunk.ReadByte());
+                        instance.PParamBlock.Add(chunk.ReadByte());
                     return instance;
             }
         }

--- a/Shared/GameFiles/WWise/Hirc/V136/CAkFxShareSet_v136.cs
+++ b/Shared/GameFiles/WWise/Hirc/V136/CAkFxShareSet_v136.cs
@@ -2,35 +2,33 @@
 
 namespace Shared.GameFormats.WWise.Hirc.V136
 {
-    //Seems like it's exactly the same as FxCustom...
-    //Not sure if there's a fancy C# way of doing things, but I just copy+pasted it below
     public class CAkFxShareSet_v136 : HircItem
     {
-        public uint plugin_id { get; set; }
+        public uint PluginId { get; set; }
         public AkPluginParam AkPluginParam { get; set; }
-        public List<AkMediaMap> mediaList { get; set; } = new List<AkMediaMap>();
-        public InitialRTPC InitialRTPC { get; set; }
+        public List<AkMediaMap> MediaList { get; set; } = [];
+        public InitialRtpc InitialRtpc { get; set; }
         public StateChunk StateChunk { get; set; }
-        public List<PluginPropertyValue> propertyValuesList { get; set; } = new List<PluginPropertyValue>();
+        public List<PluginPropertyValue> PropertyValuesList { get; set; } = [];
 
         protected override void CreateSpecificData(ByteChunk chunk)
         {
             //contains the plugin type and company id (CA doesn't have one apparently)
-            plugin_id = chunk.ReadUInt32();
+            PluginId = chunk.ReadUInt32();
 
             var uSize = chunk.ReadUInt32();
-            AkPluginParam = AkPluginParam.Create(chunk, plugin_id, uSize);
+            AkPluginParam = AkPluginParam.Create(chunk, PluginId, uSize);
 
             var uNumBankData = chunk.ReadByte();
             for (var i = 0; i < uNumBankData; i++)
-                mediaList.Add(AkMediaMap.Create(chunk));
+                MediaList.Add(AkMediaMap.Create(chunk));
 
-            InitialRTPC = InitialRTPC.Create(chunk);
+            InitialRtpc = InitialRtpc.Create(chunk);
             StateChunk = StateChunk.Create(chunk);
 
             var numValues = chunk.ReadShort();
             for (var i = 0; i < numValues; i++)
-                propertyValuesList.Add(PluginPropertyValue.Create(chunk));
+                PropertyValuesList.Add(PluginPropertyValue.Create(chunk));
         }
 
         public override void UpdateSize() => throw new NotImplementedException();

--- a/Shared/GameFiles/WWise/Hirc/V136/CAkLayerCntr_v136.cs
+++ b/Shared/GameFiles/WWise/Hirc/V136/CAkLayerCntr_v136.cs
@@ -6,10 +6,9 @@ namespace Shared.GameFormats.WWise.Hirc.V136
     {
         public NodeBaseParams NodeBaseParams { get; set; }
         public Children Children { get; set; }
-        public List<CAkLayer> LayerList { get; set; } = new List<CAkLayer>();
-        public byte bIsContinuousValidation { get; set; }
+        public List<CAkLayer> LayerList { get; set; } = [];
+        public byte BIsContinuousValidation { get; set; }
         public uint GetDirectParentId() => NodeBaseParams.DirectParentId;
-
 
         protected override void CreateSpecificData(ByteChunk chunk)
         {
@@ -20,7 +19,7 @@ namespace Shared.GameFormats.WWise.Hirc.V136
             for (var i = 0; i < layerCount; i++)
                 LayerList.Add(CAkLayer.Create(chunk));
 
-            bIsContinuousValidation = chunk.ReadByte();
+            BIsContinuousValidation = chunk.ReadByte();
         }
 
         public override void UpdateSize() => throw new NotImplementedException();
@@ -31,44 +30,42 @@ namespace Shared.GameFormats.WWise.Hirc.V136
 
     public class CAkLayer
     {
-        public uint ulLayerID { get; set; }
-        public InitialRTPC InitialRTPC { get; set; }
-        public uint rtpcID { get; set; }    // Attribute name
-        public AkRtpcType rtpcType { get; set; }
-        public List<CAssociatedChildData> CAssociatedChildDataList { get; set; } = new List<CAssociatedChildData>();
+        public uint UlLayerId { get; set; }
+        public InitialRtpc InitialRtpc { get; set; }
+        public uint RtpcId { get; set; }
+        public AkRtpcType RtpcType { get; set; }
+        public List<CAssociatedChildData> CAssociatedChildDataList { get; set; } = [];
 
         public static CAkLayer Create(ByteChunk chunk)
         {
             var instance = new CAkLayer();
-            instance.ulLayerID = chunk.ReadUInt32();
-            instance.InitialRTPC = InitialRTPC.Create(chunk);
-            instance.rtpcID = chunk.ReadUInt32();
-            instance.rtpcType = (AkRtpcType)chunk.ReadByte();
+            instance.UlLayerId = chunk.ReadUInt32();
+            instance.InitialRtpc = InitialRtpc.Create(chunk);
+            instance.RtpcId = chunk.ReadUInt32();
+            instance.RtpcType = (AkRtpcType)chunk.ReadByte();
             var ulNumAssoc = chunk.ReadUInt32();
             for (var i = 0; i < ulNumAssoc; i++)
                 instance.CAssociatedChildDataList.Add(CAssociatedChildData.Create(chunk));
-
             return instance;
         }
     }
 
     public class CAssociatedChildData
     {
-
-        public uint ulAssociatedChildID { get; set; }
-        public byte unknown_custom0 { get; set; }
-        public byte unknown_custom1 { get; set; }
-        public List<AkRTPCGraphPoint> AkRTPCGraphPointList { get; set; } = new List<AkRTPCGraphPoint>();
+        public uint UlAssociatedChildId { get; set; }
+        public byte UnknownCustom0 { get; set; }
+        public byte UnknownCustom1 { get; set; }
+        public List<AkRtpcGraphPoint> AkRtpcGraphPointList { get; set; } = [];
 
         public static CAssociatedChildData Create(ByteChunk chunk)
         {
             var instance = new CAssociatedChildData();
-            instance.ulAssociatedChildID = chunk.ReadUInt32();
-            instance.unknown_custom0 = chunk.ReadByte();
-            instance.unknown_custom1 = chunk.ReadByte();
+            instance.UlAssociatedChildId = chunk.ReadUInt32();
+            instance.UnknownCustom0 = chunk.ReadByte();
+            instance.UnknownCustom1 = chunk.ReadByte();
             var pointCount = chunk.ReadUInt32();
             for (var i = 0; i < pointCount; i++)
-                instance.AkRTPCGraphPointList.Add(AkRTPCGraphPoint.Create(chunk));
+                instance.AkRtpcGraphPointList.Add(AkRtpcGraphPoint.Create(chunk));
             return instance;
         }
     }

--- a/Shared/GameFiles/WWise/Hirc/V136/CAkMusicRanSeqCntr_v136.cs
+++ b/Shared/GameFiles/WWise/Hirc/V136/CAkMusicRanSeqCntr_v136.cs
@@ -5,8 +5,7 @@ namespace Shared.GameFormats.WWise.Hirc.V136
     public class CAkMusicRanSeqCntr_v136 : HircItem
     {
         public MusicTransNodeParams MusicTransNodeParams { get; set; }
-        public List<AkMusicRanSeqPlaylistItem> pPlayList { get; set; } = new List<AkMusicRanSeqPlaylistItem>();
-
+        public List<AkMusicRanSeqPlaylistItem> PPlayList { get; set; } = [];
 
         protected override void CreateSpecificData(ByteChunk chunk)
         {
@@ -16,16 +15,17 @@ namespace Shared.GameFormats.WWise.Hirc.V136
             var numPlaylistItems = chunk.ReadUInt32();
             //and the root always has 1, again I think...
             //for (int i = 0; i < numPlaylistItems; i++)
-            pPlayList.Add(AkMusicRanSeqPlaylistItem.Create(chunk));
+            PPlayList.Add(AkMusicRanSeqPlaylistItem.Create(chunk));
         }
 
         public override void UpdateSize() => throw new NotImplementedException();
         public override byte[] GetAsByteArray() => throw new NotImplementedException();
     }
+
     public class MusicTransNodeParams
     {
         public MusicNodeParams MusicNodeParams { get; set; }
-        public List<AkMusicTransitionRule> pPlayList { get; set; } = new List<AkMusicTransitionRule>();
+        public List<AkMusicTransitionRule> PPlayList { get; set; } = [];
 
         public static MusicTransNodeParams Create(ByteChunk chunk)
         {
@@ -35,7 +35,7 @@ namespace Shared.GameFormats.WWise.Hirc.V136
 
             var numRules = chunk.ReadUInt32();
             for (var i = 0; i < numRules; i++)
-                instance.pPlayList.Add(AkMusicTransitionRule.Create(chunk));
+                instance.PPlayList.Add(AkMusicTransitionRule.Create(chunk));
 
             return instance;
         }
@@ -43,16 +43,14 @@ namespace Shared.GameFormats.WWise.Hirc.V136
 
     public class AkMusicTransitionRule
     {
-        public uint uNumSrc { get; set; }
-        public List<uint> srcIDList { get; set; } = new List<uint>();
-
-        public uint uNumDst { get; set; }
-        public List<uint> dstIDList { get; set; } = new List<uint>();
+        public uint UNumSrc { get; set; }
+        public List<uint> SrcIdList { get; set; } = [];
+        public uint UNumDst { get; set; }
+        public List<uint> DstIdList { get; set; } = [];
         public AkMusicTransSrcRule AkMusicTransSrcRule { get; set; }
         public AkMusicTransDstRule AkMusicTransDstRule { get; set; }
-
-        public uint ulStateGroupID_custom { get; set; }
-        public uint ulStateID_custom { get; set; }
+        public uint UlStateGroupIdCustom { get; set; }
+        public uint UlStateIdCustom { get; set; }
         public byte AllocTransObjectFlag { get; set; }
         public AkMusicTransitionObject AkMusicTransitionObject { get; set; }
 
@@ -62,22 +60,21 @@ namespace Shared.GameFormats.WWise.Hirc.V136
 
             var uNumSrc = chunk.ReadUInt32();
             for (var i = 0; i < uNumSrc; i++)
-                instance.srcIDList.Add(chunk.ReadUInt32());
+                instance.SrcIdList.Add(chunk.ReadUInt32());
 
             var uNumDst = chunk.ReadUInt32();
             for (var i = 0; i < uNumDst; i++)
-                instance.dstIDList.Add(chunk.ReadUInt32());
+                instance.DstIdList.Add(chunk.ReadUInt32());
 
             instance.AkMusicTransSrcRule = AkMusicTransSrcRule.Create(chunk);
 
             instance.AkMusicTransDstRule = AkMusicTransDstRule.Create(chunk);
 
+            instance.UlStateGroupIdCustom = chunk.ReadUInt32();
+            instance.UlStateIdCustom = chunk.ReadUInt32();
 
-            instance.ulStateGroupID_custom = chunk.ReadUInt32();
-            instance.ulStateID_custom = chunk.ReadUInt32();
-
-            var AllocTransObjectFlag = chunk.ReadByte();
-            var has_transobj = AllocTransObjectFlag != 0;
+            var allocTransObjectFlag = chunk.ReadByte();
+            var has_transobj = allocTransObjectFlag != 0;
             if (has_transobj)
                 instance.AkMusicTransitionObject = AkMusicTransitionObject.Create(chunk);
 
@@ -87,22 +84,22 @@ namespace Shared.GameFormats.WWise.Hirc.V136
 
     public class AkMusicTransitionObject
     {
-        public int segmentID { get; set; }
-        public AkMusicFade fadeInParams { get; set; }
-        public AkMusicFade fadeOutParams { get; set; }
-        public byte bPlayPreEntry { get; set; }
-        public byte bPlayPostExit { get; set; }
+        public int SegmentId { get; set; }
+        public AkMusicFade FadeInParams { get; set; }
+        public AkMusicFade FadeOutParams { get; set; }
+        public byte BPlayPreEntry { get; set; }
+        public byte BPlayPostExit { get; set; }
 
         public static AkMusicTransitionObject Create(ByteChunk chunk)
         {
             var instance = new AkMusicTransitionObject();
 
-            instance.segmentID = chunk.ReadInt32();
-            instance.fadeInParams = AkMusicFade.Create(chunk);
-            instance.fadeOutParams = AkMusicFade.Create(chunk);
+            instance.SegmentId = chunk.ReadInt32();
+            instance.FadeInParams = AkMusicFade.Create(chunk);
+            instance.FadeOutParams = AkMusicFade.Create(chunk);
 
-            instance.bPlayPreEntry = chunk.ReadByte();
-            instance.bPlayPostExit = chunk.ReadByte();
+            instance.BPlayPreEntry = chunk.ReadByte();
+            instance.BPlayPostExit = chunk.ReadByte();
 
             return instance;
         }
@@ -110,44 +107,38 @@ namespace Shared.GameFormats.WWise.Hirc.V136
 
     public class AkMusicFade
     {
-        public int transitionTime { get; set; }
-        public uint eFadeCurve { get; set; }
-        public int iFadeOffset { get; set; }
-
+        public int TransitionTime { get; set; }
+        public uint EFadeCurve { get; set; }
+        public int IFadeOffset { get; set; }
 
         public static AkMusicFade Create(ByteChunk chunk)
         {
             var instance = new AkMusicFade();
-
-            instance.transitionTime = chunk.ReadInt32();
-            instance.eFadeCurve = chunk.ReadUInt32();
-            instance.iFadeOffset = chunk.ReadInt32();
-
+            instance.TransitionTime = chunk.ReadInt32();
+            instance.EFadeCurve = chunk.ReadUInt32();
+            instance.IFadeOffset = chunk.ReadInt32();
             return instance;
         }
     }
 
     public class AkMusicTransSrcRule
     {
-        public int transitionTime { get; set; }
-        public uint eFadeCurve { get; set; }
-        public int iFadeOffset { get; set; }
-        public uint eSyncType { get; set; }
-        public uint uCueFilterHash { get; set; }
-        public byte bPlayPostExit { get; set; }
-
+        public int TransitionTime { get; set; }
+        public uint EFadeCurve { get; set; }
+        public int IFadeOffset { get; set; }
+        public uint ESyncType { get; set; }
+        public uint UCueFilterHash { get; set; }
+        public byte BPlayPostExit { get; set; }
 
         public static AkMusicTransSrcRule Create(ByteChunk chunk)
         {
             var instance = new AkMusicTransSrcRule();
-
-            instance.transitionTime = chunk.ReadInt32();
-            instance.eFadeCurve = chunk.ReadUInt32();
-            instance.iFadeOffset = chunk.ReadInt32();
-            instance.eSyncType = chunk.ReadUInt32();
-            instance.uCueFilterHash = chunk.ReadUInt32();
-            instance.bPlayPostExit = chunk.ReadByte();
-
+            instance.TransitionTime = chunk.ReadInt32();
+            instance.EFadeCurve = chunk.ReadUInt32();
+            instance.IFadeOffset = chunk.ReadInt32();
+            instance.ESyncType = chunk.ReadUInt32();
+            instance.UCueFilterHash = chunk.ReadUInt32();
+            instance.BPlayPostExit = chunk.ReadByte();
             return instance;
         }
     }
@@ -155,69 +146,64 @@ namespace Shared.GameFormats.WWise.Hirc.V136
     public class AkMusicTransDstRule
     {
 
-        public int transitionTime { get; set; }
-        public uint eFadeCurve { get; set; }
-        public int iFadeOffset { get; set; }
-        public uint uCueFilterHash { get; set; }
-        public uint uJumpToID { get; set; }
-        public ushort eJumpToType { get; set; }
-        public ushort eEntryType { get; set; }
-        public byte bPlayPreEntry { get; set; }
-        public byte bDestMatchSourceCueName { get; set; }
-
+        public int TransitionTime { get; set; }
+        public uint EFadeCurve { get; set; }
+        public int IFadeOffset { get; set; }
+        public uint UCueFilterHash { get; set; }
+        public uint UJumpToId { get; set; }
+        public ushort EJumpToType { get; set; }
+        public ushort EEntryType { get; set; }
+        public byte BPlayPreEntry { get; set; }
+        public byte BDestMatchSourceCueName { get; set; }
 
         public static AkMusicTransDstRule Create(ByteChunk chunk)
         {
             var instance = new AkMusicTransDstRule();
-
-            instance.transitionTime = chunk.ReadInt32();
-            instance.eFadeCurve = chunk.ReadUInt32();
-            instance.iFadeOffset = chunk.ReadInt32();
-            instance.uCueFilterHash = chunk.ReadUInt32();
-            instance.uJumpToID = chunk.ReadUInt32();
-            instance.eJumpToType = chunk.ReadUShort();
-            instance.eEntryType = chunk.ReadUShort();
-            instance.bPlayPreEntry = chunk.ReadByte();
-            instance.bDestMatchSourceCueName = chunk.ReadByte();
-
+            instance.TransitionTime = chunk.ReadInt32();
+            instance.EFadeCurve = chunk.ReadUInt32();
+            instance.IFadeOffset = chunk.ReadInt32();
+            instance.UCueFilterHash = chunk.ReadUInt32();
+            instance.UJumpToId = chunk.ReadUInt32();
+            instance.EJumpToType = chunk.ReadUShort();
+            instance.EEntryType = chunk.ReadUShort();
+            instance.BPlayPreEntry = chunk.ReadByte();
+            instance.BDestMatchSourceCueName = chunk.ReadByte();
             return instance;
         }
     }
 
     public class AkMusicRanSeqPlaylistItem
     {
-        public uint SegmentID { get; set; }
-        public int playlistItemID { get; set; }
-        public uint eRSType { get; set; }
+        public uint SegmentId { get; set; }
+        public int PlaylistItemId { get; set; }
+        public uint ERsType { get; set; }
         public short Loop { get; set; }
         public short LoopMin { get; set; }
         public short LoopMax { get; set; }
         public uint Weight { get; set; }
-        public ushort wAvoidRepeatCount { get; set; }
-        public byte bIsUsingWeight { get; set; }
-        public byte bIsShuffle { get; set; }
-
-        public List<AkMusicRanSeqPlaylistItem> pPlayList { get; set; } = new List<AkMusicRanSeqPlaylistItem>();
-
+        public ushort WAvoidRepeatCount { get; set; }
+        public byte BIsUsingWeight { get; set; }
+        public byte BIsShuffle { get; set; }
+        public List<AkMusicRanSeqPlaylistItem> PPlayList { get; set; } = [];
 
         public static AkMusicRanSeqPlaylistItem Create(ByteChunk chunk)
         {
             var instance = new AkMusicRanSeqPlaylistItem();
 
-            instance.SegmentID = chunk.ReadUInt32();
-            instance.playlistItemID = chunk.ReadInt32();
-            var NumChildren = chunk.ReadUInt32();
-            instance.eRSType = chunk.ReadUInt32();
+            instance.SegmentId = chunk.ReadUInt32();
+            instance.PlaylistItemId = chunk.ReadInt32();
+            var numChildren = chunk.ReadUInt32();
+            instance.ERsType = chunk.ReadUInt32();
             instance.Loop = chunk.ReadShort();
             instance.LoopMin = chunk.ReadShort();
             instance.LoopMax = chunk.ReadShort();
             instance.Weight = chunk.ReadUInt32();
-            instance.wAvoidRepeatCount = chunk.ReadUShort();
-            instance.bIsUsingWeight = chunk.ReadByte();
-            instance.bIsShuffle = chunk.ReadByte();
+            instance.WAvoidRepeatCount = chunk.ReadUShort();
+            instance.BIsUsingWeight = chunk.ReadByte();
+            instance.BIsShuffle = chunk.ReadByte();
 
-            for (var i = 0; i < NumChildren; i++)
-                instance.pPlayList.Add(Create(chunk));
+            for (var i = 0; i < numChildren; i++)
+                instance.PPlayList.Add(Create(chunk));
 
             return instance;
         }

--- a/Shared/GameFiles/WWise/Hirc/V136/CAkMusicSegment_v136.cs
+++ b/Shared/GameFiles/WWise/Hirc/V136/CAkMusicSegment_v136.cs
@@ -4,22 +4,20 @@ namespace Shared.GameFormats.WWise.Hirc.V136
 {
     public class CAkMusicSegment_v136 : HircItem, INodeBaseParamsAccessor
     {
-
         public MusicNodeParams MusicNodeParams { get; set; }
-        public double fDuration { get; set; }
-        public List<AkMusicMarkerWwise> pArrayMarkersList { get; set; } = new List<AkMusicMarkerWwise>();
-
+        public double FDuration { get; set; }
+        public List<AkMusicMarkerWwise> PArrayMarkersList { get; set; } = [];
         public NodeBaseParams NodeBaseParams => MusicNodeParams.NodeBaseParams;
 
         protected override void CreateSpecificData(ByteChunk chunk)
         {
             MusicNodeParams = MusicNodeParams.Create(chunk);
 
-            fDuration = chunk.ReadInt64(); //chunk.ReadDouble();
+            FDuration = chunk.ReadInt64(); //chunk.ReadDouble();
 
             var ulNumMarkers = chunk.ReadUInt32();
             for (var i = 0; i < ulNumMarkers; i++)
-                pArrayMarkersList.Add(AkMusicMarkerWwise.Create(chunk));
+                PArrayMarkersList.Add(AkMusicMarkerWwise.Create(chunk));
         }
 
         public override void UpdateSize() => throw new NotImplementedException();
@@ -28,25 +26,25 @@ namespace Shared.GameFormats.WWise.Hirc.V136
 
     public class AkMusicMarkerWwise
     {
-        public uint id { get; set; }
-        public double fPosition { get; set; }
+        public uint Id { get; set; }
+        public double FPosition { get; set; }
 
         //see below
         //public string pMarkerName { get; set; }
-        public List<byte> pMarkerName { get; set; } = new List<byte>();
+        public List<byte> PMarkerName { get; set; } = [];
 
         public static AkMusicMarkerWwise Create(ByteChunk chunk)
         {
             var instance = new AkMusicMarkerWwise();
-            instance.id = chunk.ReadUInt32();
-            instance.fPosition = chunk.ReadInt64(); //chunk.ReadDouble();
+            instance.Id = chunk.ReadUInt32();
+            instance.FPosition = chunk.ReadInt64(); //chunk.ReadDouble();
 
             //instance.pMarkerName = chunk.ReadString();
             //The above wasn't working because uStringSize is an uint32, yet the ReadString was trying to read it as a uint16
             //So instead I just made it read the raw bytes, stored in a list
             var uStringSize = chunk.ReadUInt32();
             for (var i = 0; i < uStringSize; i++)
-                instance.pMarkerName.Add(chunk.ReadByte());
+                instance.PMarkerName.Add(chunk.ReadByte());
 
             return instance;
         }
@@ -54,25 +52,25 @@ namespace Shared.GameFormats.WWise.Hirc.V136
 
     public class MusicNodeParams
     {
-        public byte uFlags { get; set; }
+        public byte UFlags { get; set; }
         public NodeBaseParams NodeBaseParams { get; set; }
         public Children Children { get; set; }
         public AkMeterInfo AkMeterInfo { get; set; }
-        public byte bMeterInfoFlag { get; set; }
-        public List<CAkStinger> pStingersList { get; set; } = new List<CAkStinger>();
+        public byte BMeterInfoFlag { get; set; }
+        public List<CAkStinger> PStingersList { get; set; } = [];
 
         public static MusicNodeParams Create(ByteChunk chunk)
         {
             var instance = new MusicNodeParams();
-            instance.uFlags = chunk.ReadByte();
+            instance.UFlags = chunk.ReadByte();
             instance.NodeBaseParams = NodeBaseParams.Create(chunk);
             instance.Children = Children.Create(chunk);
             instance.AkMeterInfo = AkMeterInfo.Create(chunk);
-            instance.bMeterInfoFlag = chunk.ReadByte();
+            instance.BMeterInfoFlag = chunk.ReadByte();
 
-            var NumStingers = chunk.ReadUInt32();
-            for (var i = 0; i < NumStingers; i++)
-                instance.pStingersList.Add(CAkStinger.Create(chunk));
+            var numStingers = chunk.ReadUInt32();
+            for (var i = 0; i < numStingers; i++)
+                instance.PStingersList.Add(CAkStinger.Create(chunk));
 
             return instance;
         }
@@ -80,44 +78,42 @@ namespace Shared.GameFormats.WWise.Hirc.V136
 
     public class AkMeterInfo
     {
-        public double fGridPeriod { get; set; }
-        public double fGridOffset { get; set; }
-        public float fTempo { get; set; }
-        public byte uTimeSigNumBeatsBar { get; set; }
-        public byte uTimeSigBeatValue { get; set; }
+        public double FGridPeriod { get; set; }
+        public double FGridOffset { get; set; }
+        public float FTempo { get; set; }
+        public byte UTimeSigNumBeatsBar { get; set; }
+        public byte UTimeSigBeatValue { get; set; }
 
         public static AkMeterInfo Create(ByteChunk chunk)
         {
             var instance = new AkMeterInfo();
-            instance.fGridPeriod = chunk.ReadInt64(); //chunk.ReadDouble();
-            instance.fGridOffset = chunk.ReadInt64(); //chunk.ReadDouble();
-            instance.fTempo = chunk.ReadSingle();
-            instance.uTimeSigNumBeatsBar = chunk.ReadByte();
-            instance.uTimeSigBeatValue = chunk.ReadByte();
-
+            instance.FGridPeriod = chunk.ReadInt64(); //chunk.ReadDouble();
+            instance.FGridOffset = chunk.ReadInt64(); //chunk.ReadDouble();
+            instance.FTempo = chunk.ReadSingle();
+            instance.UTimeSigNumBeatsBar = chunk.ReadByte();
+            instance.UTimeSigBeatValue = chunk.ReadByte();
             return instance;
         }
     }
 
     public class CAkStinger
     {
-        public uint TriggerID { get; set; }
-        public uint SegmentID { get; set; }
+        public uint TriggerId { get; set; }
+        public uint SegmentId { get; set; }
         public uint SyncPlayAt { get; set; }
-        public uint uCueFilterHash { get; set; }
+        public uint UCueFilterHash { get; set; }
         public int DontRepeatTime { get; set; }
-        public uint numSegmentLookAhead { get; set; }
+        public uint NumSegmentLookAhead { get; set; }
 
         public static CAkStinger Create(ByteChunk chunk)
         {
             var instance = new CAkStinger();
-            instance.TriggerID = chunk.ReadUInt32();
-            instance.SegmentID = chunk.ReadUInt32();
+            instance.TriggerId = chunk.ReadUInt32();
+            instance.SegmentId = chunk.ReadUInt32();
             instance.SyncPlayAt = chunk.ReadUInt32();
-            instance.uCueFilterHash = chunk.ReadUInt32();
+            instance.UCueFilterHash = chunk.ReadUInt32();
             instance.DontRepeatTime = chunk.ReadInt32();
-            instance.numSegmentLookAhead = chunk.ReadUInt32();
-
+            instance.NumSegmentLookAhead = chunk.ReadUInt32();
             return instance;
         }
     }

--- a/Shared/GameFiles/WWise/Hirc/V136/CAkMusicSwitchCntr_v136.cs
+++ b/Shared/GameFiles/WWise/Hirc/V136/CAkMusicSwitchCntr_v136.cs
@@ -6,29 +6,24 @@ namespace Shared.GameFormats.WWise.Hirc.V136
     public class CAkMusicSwitchCntr_v136 : HircItem, INodeBaseParamsAccessor
     {
         public NodeBaseParams NodeBaseParams => MusicTransNodeParams.MusicNodeParams.NodeBaseParams;
-
         public MusicTransNodeParams MusicTransNodeParams { get; set; }
-        public byte bIsContinuePlayback { get; set; }
-
-
-
-        public uint uTreeDepth { get; set; }
+        public byte BIsContinuePlayback { get; set; }
+        public uint UTreeDepth { get; set; }
         public ArgumentList ArgumentList { get; set; }
-        public uint uTreeDataSize { get; set; }
-        public byte uMode { get; set; }
+        public uint UTreeDataSize { get; set; }
+        public byte UMode { get; set; }
         public AkDecisionTree AkDecisionTree { get; set; }
-
 
         protected override void CreateSpecificData(ByteChunk chunk)
         {
             MusicTransNodeParams = MusicTransNodeParams.Create(chunk);
-            bIsContinuePlayback = chunk.ReadByte();
+            BIsContinuePlayback = chunk.ReadByte();
 
-            uTreeDepth = chunk.ReadUInt32();
-            ArgumentList = new ArgumentList(chunk, uTreeDepth);
-            uTreeDataSize = chunk.ReadUInt32();
-            uMode = chunk.ReadByte();
-            AkDecisionTree = new AkDecisionTree(chunk, uTreeDepth, uTreeDataSize);
+            UTreeDepth = chunk.ReadUInt32();
+            ArgumentList = new ArgumentList(chunk, UTreeDepth);
+            UTreeDataSize = chunk.ReadUInt32();
+            UMode = chunk.ReadByte();
+            AkDecisionTree = new AkDecisionTree(chunk, UTreeDepth, UTreeDataSize);
         }
 
         public override void UpdateSize() => throw new NotImplementedException();

--- a/Shared/GameFiles/WWise/Hirc/V136/CAkMusicTrack_v136.cs
+++ b/Shared/GameFiles/WWise/Hirc/V136/CAkMusicTrack_v136.cs
@@ -2,80 +2,69 @@
 
 namespace Shared.GameFormats.WWise.Hirc.V136
 {
-
-
     public class CAkMusicTrack_v136 : HircItem, INodeBaseParamsAccessor, ICAkMusicTrack
     {
-
-        public byte uFlags { get; set; }
-
-        public List<AkBankSourceData> pSourceList { get; set; } = new List<AkBankSourceData>();
-
-        public List<AkTrackSrcInfo> pPlaylistList { get; set; } = new List<AkTrackSrcInfo>();
-
-        public uint numSubTrack { get; set; }
-
-        public List<AkClipAutomation> pItemsList { get; set; } = new List<AkClipAutomation>();
-
+        public byte UFlags { get; set; }
+        public List<AkBankSourceData> PSourceList { get; set; } = [];
+        public List<AkTrackSrcInfo> PPlaylistList { get; set; } = [];
+        public uint NumSubTrack { get; set; }
+        public List<AkClipAutomation> PItemsList { get; set; } = [];
         public NodeBaseParams NodeBaseParams { get; set; }
-
-        public byte eTrackType { get; set; }
-        public int iLookAheadTime { get; set; }
-
+        public byte ETrackType { get; set; }
+        public int ILookAheadTime { get; set; }
 
         protected override void CreateSpecificData(ByteChunk chunk)
         {
-            uFlags = chunk.ReadByte();
+            UFlags = chunk.ReadByte();
 
             var numSources = chunk.ReadUInt32();
             for (var i = 0; i < numSources; i++)
-                pSourceList.Add(AkBankSourceData.Create(chunk));
+                PSourceList.Add(AkBankSourceData.Create(chunk));
 
             var numPlaylistItem = chunk.ReadUInt32();
             for (var i = 0; i < numPlaylistItem; i++)
-                pPlaylistList.Add(AkTrackSrcInfo.Create(chunk));
+                PPlaylistList.Add(AkTrackSrcInfo.Create(chunk));
 
             if (numPlaylistItem > 0)
-                numSubTrack = chunk.ReadUInt32();
+                NumSubTrack = chunk.ReadUInt32();
 
             var numClipAutomationItem = chunk.ReadUInt32();
             for (var i = 0; i < numClipAutomationItem; i++)
-                pItemsList.Add(AkClipAutomation.Create(chunk));
+                PItemsList.Add(AkClipAutomation.Create(chunk));
 
             NodeBaseParams = NodeBaseParams.Create(chunk);
 
-            eTrackType = chunk.ReadByte();
+            ETrackType = chunk.ReadByte();
 
-            iLookAheadTime = chunk.ReadInt32();
+            ILookAheadTime = chunk.ReadInt32();
         }
 
         public override void UpdateSize() => throw new NotImplementedException();
         public override byte[] GetAsByteArray() => throw new NotImplementedException();
 
-        public List<uint> GetChildren() => pSourceList.Select(x => x.akMediaInformation.SourceId).ToList();
+        public List<uint> GetChildren() => PSourceList.Select(x => x.AkMediaInformation.SourceId).ToList();
     }
-
     public class AkTrackSrcInfo
     {
-        public uint trackID { get; set; }
-        public uint sourceID { get; set; }
-        public uint eventID { get; set; }
-        public double fPlayAt { get; set; }
-        public double fBeginTrimOffset { get; set; }
-        public double fEndTrimOffset { get; set; }
-        public double fSrcDuration { get; set; }
+        public uint TrackId { get; set; }
+        public uint SourceId { get; set; }
+        public uint EventId { get; set; }
+        public double FPlayAt { get; set; }
+        public double FBeginTrimOffset { get; set; }
+        public double FEndTrimOffset { get; set; }
+        public double FSrcDuration { get; set; }
 
         public static AkTrackSrcInfo Create(ByteChunk chunk)
         {
             var output = new AkTrackSrcInfo()
             {
-                trackID = chunk.ReadUInt32(),
-                sourceID = chunk.ReadUInt32(),
-                eventID = chunk.ReadUInt32(),
-                fPlayAt = chunk.ReadInt64(), //chunk.ReadDouble()
-                fBeginTrimOffset = chunk.ReadInt64(), //chunk.ReadDouble()
-                fEndTrimOffset = chunk.ReadInt64(), //chunk.ReadDouble()
-                fSrcDuration = chunk.ReadInt64(), //chunk.ReadDouble()
+                TrackId = chunk.ReadUInt32(),
+                SourceId = chunk.ReadUInt32(),
+                EventId = chunk.ReadUInt32(),
+                FPlayAt = chunk.ReadInt64(),
+                FBeginTrimOffset = chunk.ReadInt64(),
+                FEndTrimOffset = chunk.ReadInt64(),
+                FSrcDuration = chunk.ReadInt64(),
             };
             return output;
         }
@@ -83,19 +72,18 @@ namespace Shared.GameFormats.WWise.Hirc.V136
 
     public class AkClipAutomation
     {
-        public uint uClipIndex { get; set; }
-        public uint eAutoType { get; set; }
-        public List<AkRTPCGraphPoint> pRTPCMgr { get; set; } = new List<AkRTPCGraphPoint>();
+        public uint UClipIndex { get; set; }
+        public uint EAutoType { get; set; }
+        public List<AkRtpcGraphPoint> PRtpcMgr { get; set; } = [];
 
         public static AkClipAutomation Create(ByteChunk chunk)
         {
             var instance = new AkClipAutomation();
-            instance.uClipIndex = chunk.ReadUInt32();
-            instance.eAutoType = chunk.ReadUInt32();
+            instance.UClipIndex = chunk.ReadUInt32();
+            instance.EAutoType = chunk.ReadUInt32();
             var uNumPoints = chunk.ReadUInt32();
             for (var i = 0; i < uNumPoints; i++)
-                instance.pRTPCMgr.Add(AkRTPCGraphPoint.Create(chunk));
-
+                instance.PRtpcMgr.Add(AkRtpcGraphPoint.Create(chunk));
             return instance;
         }
     }

--- a/Shared/GameFiles/WWise/Hirc/V136/CAkRanSeqCntr_v136.cs
+++ b/Shared/GameFiles/WWise/Hirc/V136/CAkRanSeqCntr_v136.cs
@@ -4,40 +4,38 @@ namespace Shared.GameFormats.WWise.Hirc.V136
     public class CAkRanSeqCntr_v136 : CAkRanSeqCnt, INodeBaseParamsAccessor
     {
         public NodeBaseParams NodeBaseParams { get; set; }
-
-        public ushort sLoopCount { get; set; }
-        public ushort sLoopModMin { get; set; }
-        public ushort sLoopModMax { get; set; }
-        public float fTransitionTime { get; set; }
-        public float fTransitionTimeModMin { get; set; }
-        public float fTransitionTimeModMax { get; set; }
-        public ushort wAvoidRepeatCount { get; set; }
-        public byte eTransitionMode { get; set; }
-        public byte eRandomMode { get; set; }
-        public byte eMode { get; set; }
-        public byte byBitVector { get; set; }
-
+        public ushort SLoopCount { get; set; }
+        public ushort SLoopModMin { get; set; }
+        public ushort SLoopModMax { get; set; }
+        public float FTransitionTime { get; set; }
+        public float FTransitionTimeModMin { get; set; }
+        public float FTransitionTimeModMax { get; set; }
+        public ushort WAvoidRepeatCount { get; set; }
+        public byte ETransitionMode { get; set; }
+        public byte ERandomMode { get; set; }
+        public byte EMode { get; set; }
+        public byte ByBitVector { get; set; }
         public Children Children { get; set; }
-        public List<AkPlaylistItem> AkPlaylist { get; set; } = new List<AkPlaylistItem>();
+        public List<AkPlaylistItem> AkPlaylist { get; set; } = [];
 
         protected override void CreateSpecificData(ByteChunk chunk)
         {
             NodeBaseParams = NodeBaseParams.Create(chunk);
 
-            sLoopCount = chunk.ReadUShort();
-            sLoopModMin = chunk.ReadUShort();
-            sLoopModMax = chunk.ReadUShort();
+            SLoopCount = chunk.ReadUShort();
+            SLoopModMin = chunk.ReadUShort();
+            SLoopModMax = chunk.ReadUShort();
 
-            fTransitionTime = chunk.ReadSingle();
-            fTransitionTimeModMin = chunk.ReadSingle();
-            fTransitionTimeModMax = chunk.ReadSingle();
+            FTransitionTime = chunk.ReadSingle();
+            FTransitionTimeModMin = chunk.ReadSingle();
+            FTransitionTimeModMax = chunk.ReadSingle();
 
-            wAvoidRepeatCount = chunk.ReadUShort();
+            WAvoidRepeatCount = chunk.ReadUShort();
 
-            eTransitionMode = chunk.ReadByte();
-            eRandomMode = chunk.ReadByte();
-            eMode = chunk.ReadByte();
-            byBitVector = chunk.ReadByte();
+            ETransitionMode = chunk.ReadByte();
+            ERandomMode = chunk.ReadByte();
+            EMode = chunk.ReadByte();
+            ByBitVector = chunk.ReadByte();
 
             Children = Children.Create(chunk);
 
@@ -53,7 +51,7 @@ namespace Shared.GameFormats.WWise.Hirc.V136
         {
             var nodeBaseParams = NodeBaseParams.GetSize();
             var children = Children.GetSize();
-            var akPlaylistCount = Convert.ToUInt32(AkPlaylist.Count());
+            var akPlaylistCount = Convert.ToUInt32(AkPlaylist.Count);
 
             Size = BnkChunkHeader.HeaderByteSize + nodeBaseParams + 2 + 2 + 2 + 4 + 4 + 4 + 2 + 1 + 1 + 1 + 1 + children + 2 + akPlaylistCount * 8 - 4;
         }
@@ -63,20 +61,20 @@ namespace Shared.GameFormats.WWise.Hirc.V136
             using var memStream = WriteHeader();
             memStream.Write(NodeBaseParams.GetAsByteArray());
 
-            memStream.Write(ByteParsers.UShort.EncodeValue(sLoopCount, out _));
-            memStream.Write(ByteParsers.UShort.EncodeValue(sLoopModMin, out _));
-            memStream.Write(ByteParsers.UShort.EncodeValue(sLoopModMax, out _));
+            memStream.Write(ByteParsers.UShort.EncodeValue(SLoopCount, out _));
+            memStream.Write(ByteParsers.UShort.EncodeValue(SLoopModMin, out _));
+            memStream.Write(ByteParsers.UShort.EncodeValue(SLoopModMax, out _));
 
-            memStream.Write(ByteParsers.Single.EncodeValue(fTransitionTime, out _));
-            memStream.Write(ByteParsers.Single.EncodeValue(fTransitionTimeModMin, out _));
-            memStream.Write(ByteParsers.Single.EncodeValue(fTransitionTimeModMax, out _));
+            memStream.Write(ByteParsers.Single.EncodeValue(FTransitionTime, out _));
+            memStream.Write(ByteParsers.Single.EncodeValue(FTransitionTimeModMin, out _));
+            memStream.Write(ByteParsers.Single.EncodeValue(FTransitionTimeModMax, out _));
 
-            memStream.Write(ByteParsers.UShort.EncodeValue(wAvoidRepeatCount, out _));
+            memStream.Write(ByteParsers.UShort.EncodeValue(WAvoidRepeatCount, out _));
 
-            memStream.Write(ByteParsers.Byte.EncodeValue(eTransitionMode, out _));
-            memStream.Write(ByteParsers.Byte.EncodeValue(eRandomMode, out _));
-            memStream.Write(ByteParsers.Byte.EncodeValue(eMode, out _));
-            memStream.Write(ByteParsers.Byte.EncodeValue(byBitVector, out _));
+            memStream.Write(ByteParsers.Byte.EncodeValue(ETransitionMode, out _));
+            memStream.Write(ByteParsers.Byte.EncodeValue(ERandomMode, out _));
+            memStream.Write(ByteParsers.Byte.EncodeValue(EMode, out _));
+            memStream.Write(ByteParsers.Byte.EncodeValue(ByBitVector, out _));
 
             memStream.Write(Children.GetAsByteArray());
 

--- a/Shared/GameFiles/WWise/Hirc/V136/CAkSound_v136.cs
+++ b/Shared/GameFiles/WWise/Hirc/V136/CAkSound_v136.cs
@@ -14,7 +14,7 @@ namespace Shared.GameFormats.WWise.Hirc.V136
         }
 
         public uint GetDirectParentId() => NodeBaseParams.DirectParentId;
-        public uint GetSourceId() => AkBankSourceData.akMediaInformation.SourceId;
+        public uint GetSourceId() => AkBankSourceData.AkMediaInformation.SourceId;
         public SourceType GetStreamType() => AkBankSourceData.StreamType;
 
         public override void UpdateSize()
@@ -41,12 +41,12 @@ namespace Shared.GameFormats.WWise.Hirc.V136
     public class AkBankSourceData
     {
         public uint PluginId { get; set; }
-        public ushort PluginId_type { get; set; }
-        public ushort PluginId_company { get; set; }
+        public ushort PluginIdType { get; set; }
+        public ushort PluginIdCompany { get; set; }
         public SourceType StreamType { get; set; }
+        public AkMediaInformation AkMediaInformation { get; set; }
+        public uint USize { get; set; }
 
-        public AkMediaInformation akMediaInformation { get; set; }
-        public uint uSize { get; set; }
         public static AkBankSourceData Create(ByteChunk chunk)
         {
             var output = new AkBankSourceData()
@@ -55,51 +55,49 @@ namespace Shared.GameFormats.WWise.Hirc.V136
                 StreamType = (SourceType)chunk.ReadByte()
             };
 
-            output.PluginId_type = (ushort)(output.PluginId >> 0 & 0x000F);
-            output.PluginId_company = (ushort)(output.PluginId >> 4 & 0x03FF);
+            output.PluginIdType = (ushort)(output.PluginId >> 0 & 0x000F);
+            output.PluginIdCompany = (ushort)(output.PluginId >> 4 & 0x03FF);
 
             if (output.StreamType != SourceType.Streaming)
             {
                 //   throw new Exception();
             }
 
-            if (output.PluginId_type == 0x02)
-                output.uSize = chunk.ReadUInt32();
+            if (output.PluginIdType == 0x02)
+                output.USize = chunk.ReadUInt32();
 
-            output.akMediaInformation = AkMediaInformation.Create(chunk);
+            output.AkMediaInformation = AkMediaInformation.Create(chunk);
 
             return output;
         }
 
-        public uint GetSize() => 14;
+        public static uint GetSize() => 14;
 
         public byte[] GetAsByteArray()
         {
             using var memStream = new MemoryStream();
             memStream.Write(ByteParsers.UInt32.EncodeValue(PluginId, out _));
             memStream.Write(ByteParsers.Byte.EncodeValue((byte)StreamType, out _));
-            memStream.Write(ByteParsers.UInt32.EncodeValue(akMediaInformation.SourceId, out _));
-            memStream.Write(ByteParsers.UInt32.EncodeValue(akMediaInformation.uInMemoryMediaSize, out _));
-            memStream.Write(ByteParsers.Byte.EncodeValue(akMediaInformation.uSourceBits, out _));
+            memStream.Write(ByteParsers.UInt32.EncodeValue(AkMediaInformation.SourceId, out _));
+            memStream.Write(ByteParsers.UInt32.EncodeValue(AkMediaInformation.UInMemoryMediaSize, out _));
+            memStream.Write(ByteParsers.Byte.EncodeValue(AkMediaInformation.USourceBits, out _));
             return memStream.ToArray();
         }
-
-
     }
 
     public class AkMediaInformation
     {
         public uint SourceId { get; set; }
-        public uint uInMemoryMediaSize { get; set; }
-        public byte uSourceBits { get; set; }
+        public uint UInMemoryMediaSize { get; set; }
+        public byte USourceBits { get; set; }
 
         public static AkMediaInformation Create(ByteChunk chunk)
         {
             return new AkMediaInformation()
             {
                 SourceId = chunk.ReadUInt32(),
-                uInMemoryMediaSize = chunk.ReadUInt32(),
-                uSourceBits = chunk.ReadByte(),
+                UInMemoryMediaSize = chunk.ReadUInt32(),
+                USourceBits = chunk.ReadByte(),
             };
         }
     }

--- a/Shared/GameFiles/WWise/Hirc/V136/CAkSwitchCntr_v136.cs
+++ b/Shared/GameFiles/WWise/Hirc/V136/CAkSwitchCntr_v136.cs
@@ -2,27 +2,25 @@
 
 namespace Shared.GameFormats.WWise.Hirc.V136
 {
-
     public class CAkSwitchCntr_v136 : HircItem, INodeBaseParamsAccessor, ICAkSwitchCntr
     {
         public NodeBaseParams NodeBaseParams { get; set; }
-        public AkGroupType eGroupType { get; set; }
-        public uint ulGroupID { get; set; }   // Enum group name
-        public uint ulDefaultSwitch { get; set; }    // Default value name
-        public byte bIsContinuousValidation { get; set; }
+        public AkGroupType EGroupType { get; set; }
+        public uint UlGroupId { get; set; }
+        public uint UlDefaultSwitch { get; set; }
+        public byte BIsContinuousValidation { get; set; }
         public Children Children { get; set; }
-        public List<ICAkSwitchCntr.ICAkSwitchPackage> SwitchList { get; set; } = new();
-        public List<AkSwitchNodeParams> Parameters { get; set; } = new();
+        public List<ICAkSwitchCntr.ICAkSwitchPackage> SwitchList { get; set; } = [];
+        public List<AkSwitchNodeParams> Parameters { get; set; } = [];
         public uint GetDirectParentId() => NodeBaseParams.DirectParentId;
-
 
         protected override void CreateSpecificData(ByteChunk chunk)
         {
             NodeBaseParams = NodeBaseParams.Create(chunk);
-            eGroupType = (AkGroupType)chunk.ReadByte();
-            ulGroupID = chunk.ReadUInt32();
-            ulDefaultSwitch = chunk.ReadUInt32();
-            bIsContinuousValidation = chunk.ReadByte();
+            EGroupType = (AkGroupType)chunk.ReadByte();
+            UlGroupId = chunk.ReadUInt32();
+            UlDefaultSwitch = chunk.ReadUInt32();
+            BIsContinuousValidation = chunk.ReadByte();
             Children = Children.Create(chunk);
 
             var switchListCount = chunk.ReadUInt32();
@@ -36,8 +34,7 @@ namespace Shared.GameFormats.WWise.Hirc.V136
 
         public override void UpdateSize() => throw new NotImplementedException();
         public override byte[] GetAsByteArray() => throw new NotImplementedException();
-
-        public uint GroupId { get => ulGroupID; }
-        public uint DefaultSwitch { get => ulDefaultSwitch; }
+        public uint GroupId { get => UlGroupId; }
+        public uint DefaultSwitch { get => UlDefaultSwitch; }
     }
 }

--- a/Shared/GameFiles/WWise/Hirc/V136/Common.cs
+++ b/Shared/GameFiles/WWise/Hirc/V136/Common.cs
@@ -4,7 +4,7 @@ namespace Shared.GameFormats.WWise.Hirc.V136
 {
     public class Children
     {
-        public List<uint> ChildIdList { get; set; } = new List<uint>(); // Probably the name of something, or at least a reference to something interesting
+        public List<uint> ChildIdList { get; set; } = [];
 
         public static Children Create(ByteChunk chunk)
         {
@@ -12,7 +12,6 @@ namespace Shared.GameFormats.WWise.Hirc.V136
             var numChildren = chunk.ReadUInt32();
             for (var i = 0; i < numChildren; i++)
                 instance.ChildIdList.Add(chunk.ReadUInt32());
-
             return instance;
         }
 
@@ -36,12 +35,10 @@ namespace Shared.GameFormats.WWise.Hirc.V136
         }
     }
 
-
-
     public class CAkSwitchPackage : ICAkSwitchCntr.ICAkSwitchPackage
     {
-        public uint SwitchId { get; set; }  // ID/Name of the switch case
-        public List<uint> NodeIdList { get; set; } = new List<uint>(); // Probably the name of something, or at least a reference to something interesting
+        public uint SwitchId { get; set; }
+        public List<uint> NodeIdList { get; set; } = [];
 
         public static CAkSwitchPackage Create(ByteChunk chunk)
         {
@@ -50,7 +47,6 @@ namespace Shared.GameFormats.WWise.Hirc.V136
             var numChildren = chunk.ReadUInt32();
             for (var i = 0; i < numChildren; i++)
                 instance.NodeIdList.Add(chunk.ReadUInt32());
-
             return instance;
         }
     }
@@ -60,7 +56,6 @@ namespace Shared.GameFormats.WWise.Hirc.V136
         public uint NodeId { get; set; }
         public byte BitVector0 { get; set; }
         public byte BitVector1 { get; set; }
-
         public float FadeOutTime { get; set; }
         public float FadeInTime { get; set; }
 
@@ -72,7 +67,6 @@ namespace Shared.GameFormats.WWise.Hirc.V136
             instance.BitVector1 = chunk.ReadByte();
             instance.FadeOutTime = chunk.ReadSingle();
             instance.FadeInTime = chunk.ReadSingle();
-
             return instance;
         }
     }
@@ -80,41 +74,35 @@ namespace Shared.GameFormats.WWise.Hirc.V136
     public class NodeBaseParams
     {
         public NodeInitialFxParams NodeInitialFxParams { get; set; }
-        public byte bOverrideAttachmentParams { get; set; }
+        public byte BOverrideAttachmentParams { get; set; }
         public uint OverrideBusId { get; set; }
         public uint DirectParentId { get; set; }
-        public byte byBitVector { get; set; }
-
+        public byte ByBitVector { get; set; }
         public NodeInitialParams NodeInitialParams { get; set; }
         public PositioningParams PositioningParams { get; set; }
         public AuxParams AuxParams { get; set; }
         public AdvSettingsParams AdvSettingsParams { get; set; }
         public StateChunk StateChunk { get; set; }
-        public InitialRTPC InitialRTPC { get; set; }
-
-
-        public byte eGroupType { get; set; } // "Switch"
-        public uint ulGroupID { get; set; }     // Enum switch name
-        public uint ulDefaultSwitch { get; set; }   // Enum switch defautl value
-        public byte bIsContinuousValidation { get; set; } // "Switch"
+        public InitialRtpc InitialRtpc { get; set; }
+        public byte EGroupType { get; set; }
+        public uint UlGroupId { get; set; }
+        public uint UlDefaultSwitch { get; set; }
+        public byte BIsContinuousValidation { get; set; }
 
         public static NodeBaseParams Create(ByteChunk chunk)
         {
             var node = new NodeBaseParams();
             node.NodeInitialFxParams = NodeInitialFxParams.Create(chunk);
-
-            node.bOverrideAttachmentParams = chunk.ReadByte();
+            node.BOverrideAttachmentParams = chunk.ReadByte();
             node.OverrideBusId = chunk.ReadUInt32();
             node.DirectParentId = chunk.ReadUInt32();
-            node.byBitVector = chunk.ReadByte();
-
+            node.ByBitVector = chunk.ReadByte();
             node.NodeInitialParams = NodeInitialParams.Create(chunk);
             node.PositioningParams = PositioningParams.Create(chunk);
             node.AuxParams = AuxParams.Create(chunk);
             node.AdvSettingsParams = AdvSettingsParams.Create(chunk);
             node.StateChunk = StateChunk.Create(chunk);
-            node.InitialRTPC = InitialRTPC.Create(chunk);
-
+            node.InitialRtpc = InitialRtpc.Create(chunk);
             return node;
         }
 
@@ -123,14 +111,14 @@ namespace Shared.GameFormats.WWise.Hirc.V136
             var instance = new NodeBaseParams();
             instance.NodeInitialFxParams = new NodeInitialFxParams()
             {
-                bIsOverrideParentFX = 0,
+                BIsOverrideParentFX = 0,
                 FxList = new List<FXChunk>(),
-                bitsFXBypass = 0,
+                BitsFXBypass = 0,
             };
-            instance.bOverrideAttachmentParams = 0;
+            instance.BOverrideAttachmentParams = 0;
             instance.OverrideBusId = 0;
             instance.DirectParentId = 0;
-            instance.byBitVector = 0;
+            instance.ByBitVector = 0;
             instance.NodeInitialParams = new NodeInitialParams()
             {
                 AkPropBundle0 = new AkPropBundle()
@@ -147,27 +135,26 @@ namespace Shared.GameFormats.WWise.Hirc.V136
                     Values = new List<AkPropBundleMinMax.AkPropBundleInstance>()
                 }
             };
-
             instance.PositioningParams = new PositioningParams()
             {
-                uBitsPositioning = 0x03,
-                uBits3d = 0x08
+                UBitsPositioning = 0x03,
+                UBits3d = 0x08
             };
             instance.AuxParams = new AuxParams()
             {
-                byBitVector = 0,
-                reflectionsAuxBus = 0
+                ByBitVector = 0,
+                ReflectionsAuxBus = 0
             };
             instance.AdvSettingsParams = new AdvSettingsParams()
             {
-                byBitVector = 0x00,
-                eVirtualQueueBehavior = 0x01,
-                u16MaxNumInstance = 0,
-                eBelowThresholdBehavior = 0,
-                byBitVector2 = 0
+                ByBitVector = 0x00,
+                EVirtualQueueBehavior = 0x01,
+                U16MaxNumInstance = 0,
+                EBelowThresholdBehavior = 0,
+                ByBitVector2 = 0
             };
             instance.StateChunk = new StateChunk();
-            instance.InitialRTPC = new InitialRTPC();
+            instance.InitialRtpc = new InitialRtpc();
             return instance;
         }
 
@@ -176,14 +163,14 @@ namespace Shared.GameFormats.WWise.Hirc.V136
             var instance = new NodeBaseParams();
             instance.NodeInitialFxParams = new NodeInitialFxParams()
             {
-                bIsOverrideParentFX = 0,
+                BIsOverrideParentFX = 0,
                 FxList = new List<FXChunk>(),
-                bitsFXBypass = 0,
+                BitsFXBypass = 0,
             };
-            instance.bOverrideAttachmentParams = 0;
+            instance.BOverrideAttachmentParams = 0;
             instance.OverrideBusId = 0;
             instance.DirectParentId = 0;
-            instance.byBitVector = 0x02;
+            instance.ByBitVector = 0x02;
             instance.NodeInitialParams = new NodeInitialParams()
             {
                 AkPropBundle0 = new AkPropBundle()
@@ -200,23 +187,23 @@ namespace Shared.GameFormats.WWise.Hirc.V136
 
             instance.PositioningParams = new PositioningParams()
             {
-                uBitsPositioning = 0x00,
+                UBitsPositioning = 0x00,
             };
             instance.AuxParams = new AuxParams()
             {
-                byBitVector = 0,
-                reflectionsAuxBus = 0
+                ByBitVector = 0,
+                ReflectionsAuxBus = 0
             };
             instance.AdvSettingsParams = new AdvSettingsParams()
             {
-                byBitVector = 0x00,
-                eVirtualQueueBehavior = 0x01,
-                u16MaxNumInstance = 0,
-                eBelowThresholdBehavior = 0x02,
-                byBitVector2 = 0
+                ByBitVector = 0x00,
+                EVirtualQueueBehavior = 0x01,
+                U16MaxNumInstance = 0,
+                EBelowThresholdBehavior = 0x02,
+                ByBitVector2 = 0
             };
             instance.StateChunk = new StateChunk();
-            instance.InitialRTPC = new InitialRTPC();
+            instance.InitialRtpc = new InitialRtpc();
             return instance;
         }
 
@@ -225,18 +212,17 @@ namespace Shared.GameFormats.WWise.Hirc.V136
             using var memStream = new MemoryStream();
             memStream.Write(NodeInitialFxParams.GetAsByteArray());
 
-            memStream.Write(ByteParsers.Byte.EncodeValue(bOverrideAttachmentParams, out _));
+            memStream.Write(ByteParsers.Byte.EncodeValue(BOverrideAttachmentParams, out _));
             memStream.Write(ByteParsers.UInt32.EncodeValue(OverrideBusId, out _));
             memStream.Write(ByteParsers.UInt32.EncodeValue(DirectParentId, out _));
-            memStream.Write(ByteParsers.Byte.EncodeValue(byBitVector, out _));
+            memStream.Write(ByteParsers.Byte.EncodeValue(ByBitVector, out _));
 
             memStream.Write(NodeInitialParams.GetAsByteArray());
             memStream.Write(PositioningParams.GetAsByteArray());
             memStream.Write(AuxParams.GetAsByteArray());
             memStream.Write(AdvSettingsParams.GetAsByteArray());
             memStream.Write(StateChunk.GetAsByteArray());
-            memStream.Write(InitialRTPC.GetAsByteArray());
-
+            memStream.Write(InitialRtpc.GetAsByteArray());
 
             var byteArray = memStream.ToArray();
             if (byteArray.Length != GetSize())
@@ -246,7 +232,7 @@ namespace Shared.GameFormats.WWise.Hirc.V136
 
         internal uint GetSize()
         {
-            return NodeInitialFxParams.GetSize() + 10 + NodeInitialParams.GetSize() + PositioningParams.GetSize() + AuxParams.GetSize() + AdvSettingsParams.GetSize() + StateChunk.GetSize() + InitialRTPC.GetSize();
+            return NodeInitialFxParams.GetSize() + 10 + NodeInitialParams.GetSize() + PositioningParams.GetSize() + AuxParams.GetSize() + AdvSettingsParams.GetSize() + StateChunk.GetSize() + InitialRtpc.GetSize();
         }
     }
 
@@ -283,7 +269,7 @@ namespace Shared.GameFormats.WWise.Hirc.V136
             public uint Value { get; set; }
         }
 
-        public List<AkPropBundleInstance> Values { get; set; } = new List<AkPropBundleInstance>();
+        public List<AkPropBundleInstance> Values { get; set; } = [];
 
         public static AkPropBundle Create(ByteChunk chunk)
         {
@@ -327,7 +313,7 @@ namespace Shared.GameFormats.WWise.Hirc.V136
             public float Max { get; set; }
         }
 
-        public List<AkPropBundleInstance> Values { get; set; } = new List<AkPropBundleInstance>();
+        public List<AkPropBundleInstance> Values { get; set; } = [];
 
         public static AkPropBundleMinMax Create(ByteChunk chunk)
         {
@@ -370,19 +356,19 @@ namespace Shared.GameFormats.WWise.Hirc.V136
 
     public class NodeInitialFxParams
     {
-        public byte bIsOverrideParentFX { get; set; }
-        public byte bitsFXBypass { get; set; }
-        public List<FXChunk> FxList { get; set; } = new List<FXChunk>();
+        public byte BIsOverrideParentFX { get; set; }
+        public byte BitsFXBypass { get; set; }
+        public List<FXChunk> FxList { get; set; } = [];
 
         public static NodeInitialFxParams Create(ByteChunk chunk)
         {
             var instance = new NodeInitialFxParams();
-            instance.bIsOverrideParentFX = chunk.ReadByte();
+            instance.BIsOverrideParentFX = chunk.ReadByte();
             var uNumFx = chunk.ReadByte();
 
             if (uNumFx != 0)
             {
-                instance.bitsFXBypass = chunk.ReadByte();
+                instance.BitsFXBypass = chunk.ReadByte();
                 for (var i = 0; i < uNumFx; i++)
                     instance.FxList.Add(FXChunk.Create(chunk));
             }
@@ -390,67 +376,63 @@ namespace Shared.GameFormats.WWise.Hirc.V136
             return instance;
         }
 
-        public uint GetSize() => 2;
+        public static uint GetSize() => 2;
 
         public byte[] GetAsByteArray()
         {
             using var memStream = new MemoryStream();
-            memStream.Write(ByteParsers.Byte.EncodeValue(bIsOverrideParentFX, out _));
-            memStream.Write(ByteParsers.Byte.EncodeValue(bitsFXBypass, out _));
+            memStream.Write(ByteParsers.Byte.EncodeValue(BIsOverrideParentFX, out _));
+            memStream.Write(ByteParsers.Byte.EncodeValue(BitsFXBypass, out _));
             return memStream.ToArray();
         }
     }
 
     public class FXChunk
     {
-        public byte uFXIndex { get; set; }
-        public uint fxID { get; set; }
-        public byte bIsShareSet { get; set; }
-        public byte bIsRendered { get; set; }
+        public byte UFxIndex { get; set; }
+        public uint FxId { get; set; }
+        public byte BIsShareSet { get; set; }
+        public byte BIsRendered { get; set; }
 
         public static FXChunk Create(ByteChunk chunk)
         {
             var instance = new FXChunk();
-            instance.uFXIndex = chunk.ReadByte();
-            instance.fxID = chunk.ReadUInt32();
-            instance.bIsShareSet = chunk.ReadByte();
-            instance.bIsRendered = chunk.ReadByte();
+            instance.UFxIndex = chunk.ReadByte();
+            instance.FxId = chunk.ReadUInt32();
+            instance.BIsShareSet = chunk.ReadByte();
+            instance.BIsRendered = chunk.ReadByte();
             return instance;
         }
     }
 
-
     public class PositioningParams
     {
-        public byte uBitsPositioning { get; set; }
-        public byte uBits3d { get; set; }
-        public byte ePathMode { get; set; }
+        public byte UBitsPositioning { get; set; }
+        public byte UBits3d { get; set; }
+        public byte EPathMode { get; set; }
         public float TransitionTime { get; set; }
-
-
-
-        public List<AkPathVertex> VertexList { get; set; } = new List<AkPathVertex>();
-        public List<AkPathListItemOffset> PlayListItems { get; set; } = new List<AkPathListItemOffset>();
-        public List<Ak3DAutomationParams> Params { get; set; } = new List<Ak3DAutomationParams>();
+        public List<AkPathVertex> VertexList { get; set; } = [];
+        public List<AkPathListItemOffset> PlayListItems { get; set; } = [];
+        public List<Ak3DAutomationParams> Params { get; set; } = [];
 
         public static PositioningParams Create(ByteChunk chunk)
         {
             var instance = new PositioningParams();
-            instance.uBitsPositioning = chunk.ReadByte();
+            instance.UBitsPositioning = chunk.ReadByte();
 
-            var has_positioning = (instance.uBitsPositioning >> 0 & 1) == 1;
-            var has_3d = (instance.uBitsPositioning >> 1 & 1) == 1;
+            var has_positioning = (instance.UBitsPositioning >> 0 & 1) == 1;
+            var has_3d = (instance.UBitsPositioning >> 1 & 1) == 1;
 
             if (has_positioning && has_3d)
             {
-                instance.uBits3d = chunk.ReadByte();
+                instance.UBits3d = chunk.ReadByte();
 
-                var e3DPositionType = instance.uBitsPositioning >> 5 & 3;
+                var e3DPositionType = instance.UBitsPositioning >> 5 & 3;
                 var has_automation = e3DPositionType != 0;
 
                 if (has_automation)
                 {
-                    instance.ePathMode = chunk.ReadByte();
+                    instance.EPathMode = chunk.ReadByte();
                     instance.TransitionTime = chunk.ReadSingle();
 
                     var numVertexes = chunk.ReadUInt32();
@@ -471,24 +453,20 @@ namespace Shared.GameFormats.WWise.Hirc.V136
 
         public uint GetSize()
         {
-            if (uBitsPositioning == 0x03 && uBits3d == 0x08)
+            if (UBitsPositioning == 0x03 && UBits3d == 0x08)
                 return 2;
-
-            else if (uBitsPositioning == 0x00)
+            else if (UBitsPositioning == 0x00)
                 return 1;
-
             else
                 throw new NotImplementedException();
         }
 
         public byte[] GetAsByteArray()
         {
-            if (uBitsPositioning == 0x03 && uBits3d == 0x08)
-                return new byte[] { 0x03, 0x08 };
-
-            else if (uBitsPositioning == 0x00)
-                return new byte[] { 0x00 };
-
+            if (UBitsPositioning == 0x03 && UBits3d == 0x08)
+                return [0x03, 0x08];
+            else if (UBitsPositioning == 0x00)
+                return [0x00];
             else
                 throw new NotImplementedException();
         }
@@ -508,22 +486,20 @@ namespace Shared.GameFormats.WWise.Hirc.V136
             instance.Y = chunk.ReadSingle();
             instance.Z = chunk.ReadSingle();
             instance.Duration = chunk.ReadInt32();
-
             return instance;
         }
     }
 
     public class AkPathListItemOffset
     {
-        public uint ulVerticesOffset { get; set; }
-        public uint iNumVertices { get; set; }
+        public uint UlVerticesOffset { get; set; }
+        public uint INumVertices { get; set; }
 
         public static AkPathListItemOffset Create(ByteChunk chunk)
         {
             var instance = new AkPathListItemOffset();
-            instance.ulVerticesOffset = chunk.ReadUInt32();
-            instance.iNumVertices = chunk.ReadUInt32();
-
+            instance.UlVerticesOffset = chunk.ReadUInt32();
+            instance.INumVertices = chunk.ReadUInt32();
             return instance;
         }
     }
@@ -540,49 +516,47 @@ namespace Shared.GameFormats.WWise.Hirc.V136
             instance.X = chunk.ReadSingle();
             instance.Y = chunk.ReadSingle();
             instance.Z = chunk.ReadSingle();
-
             return instance;
         }
     }
 
     public class AuxParams
     {
-        public byte byBitVector { get; set; }
-        public uint auxBus0 { get; set; }
-        public uint auxBus1 { get; set; }
-        public uint auxBus2 { get; set; }
-        public uint auxBus3 { get; set; }
-        public uint reflectionsAuxBus { get; set; }
+        public byte ByBitVector { get; set; }
+        public uint AuxBus0 { get; set; }
+        public uint AuxBus1 { get; set; }
+        public uint AuxBus2 { get; set; }
+        public uint AuxBus3 { get; set; }
+        public uint ReflectionsAuxBus { get; set; }
 
         public static AuxParams Create(ByteChunk chunk)
         {
             var instance = new AuxParams();
-            instance.byBitVector = chunk.ReadByte();
+            instance.ByBitVector = chunk.ReadByte();
 
-            if ((instance.byBitVector >> 3 & 1) == 1)
+            if ((instance.ByBitVector >> 3 & 1) == 1)
             {
-                instance.auxBus0 = chunk.ReadUInt32();
-                instance.auxBus1 = chunk.ReadUInt32();
-                instance.auxBus2 = chunk.ReadUInt32();
-                instance.auxBus3 = chunk.ReadUInt32();
+                instance.AuxBus0 = chunk.ReadUInt32();
+                instance.AuxBus1 = chunk.ReadUInt32();
+                instance.AuxBus2 = chunk.ReadUInt32();
+                instance.AuxBus3 = chunk.ReadUInt32();
             }
 
-            instance.reflectionsAuxBus = chunk.ReadUInt32();
+            instance.ReflectionsAuxBus = chunk.ReadUInt32();
 
             return instance;
         }
 
-
-        public uint GetSize() => 5;
+        public static uint GetSize() => 5;
 
         public byte[] GetAsByteArray()
         {
-            if (byBitVector != 0)
+            if (ByBitVector != 0)
                 throw new NotImplementedException();
 
             using var memStream = new MemoryStream();
-            memStream.Write(ByteParsers.Byte.EncodeValue(byBitVector, out _));
-            memStream.Write(ByteParsers.UInt32.EncodeValue(reflectionsAuxBus, out _));
+            memStream.Write(ByteParsers.Byte.EncodeValue(ByBitVector, out _));
+            memStream.Write(ByteParsers.UInt32.EncodeValue(ReflectionsAuxBus, out _));
 
             var byteArray = memStream.ToArray();
             if (byteArray.Length != GetSize())
@@ -591,40 +565,35 @@ namespace Shared.GameFormats.WWise.Hirc.V136
         }
     }
 
-
     public class AdvSettingsParams
     {
-        public byte byBitVector { get; set; }
-        public byte eVirtualQueueBehavior { get; set; }
-        public ushort u16MaxNumInstance { get; set; }
-        public byte eBelowThresholdBehavior { get; set; }
-        public byte byBitVector2 { get; set; }
-
-
+        public byte ByBitVector { get; set; }
+        public byte EVirtualQueueBehavior { get; set; }
+        public ushort U16MaxNumInstance { get; set; }
+        public byte EBelowThresholdBehavior { get; set; }
+        public byte ByBitVector2 { get; set; }
 
         public static AdvSettingsParams Create(ByteChunk chunk)
         {
             var node = new AdvSettingsParams();
-
-            node.byBitVector = chunk.ReadByte();
-            node.eVirtualQueueBehavior = chunk.ReadByte();
-            node.u16MaxNumInstance = chunk.ReadUShort();
-            node.eBelowThresholdBehavior = chunk.ReadByte();
-            node.byBitVector2 = chunk.ReadByte();
-
+            node.ByBitVector = chunk.ReadByte();
+            node.EVirtualQueueBehavior = chunk.ReadByte();
+            node.U16MaxNumInstance = chunk.ReadUShort();
+            node.EBelowThresholdBehavior = chunk.ReadByte();
+            node.ByBitVector2 = chunk.ReadByte();
             return node;
         }
 
-        public uint GetSize() => 6;
+        public static uint GetSize() => 6;
 
         public byte[] GetAsByteArray()
         {
             using var memStream = new MemoryStream();
-            memStream.Write(ByteParsers.Byte.EncodeValue(byBitVector, out _));
-            memStream.Write(ByteParsers.Byte.EncodeValue(eVirtualQueueBehavior, out _));
-            memStream.Write(ByteParsers.UShort.EncodeValue((byte)u16MaxNumInstance, out _));
-            memStream.Write(ByteParsers.Byte.EncodeValue(eBelowThresholdBehavior, out _));
-            memStream.Write(ByteParsers.Byte.EncodeValue(byBitVector2, out _));
+            memStream.Write(ByteParsers.Byte.EncodeValue(ByBitVector, out _));
+            memStream.Write(ByteParsers.Byte.EncodeValue(EVirtualQueueBehavior, out _));
+            memStream.Write(ByteParsers.UShort.EncodeValue((byte)U16MaxNumInstance, out _));
+            memStream.Write(ByteParsers.Byte.EncodeValue(EBelowThresholdBehavior, out _));
+            memStream.Write(ByteParsers.Byte.EncodeValue(ByBitVector2, out _));
 
             var byteArray = memStream.ToArray();
             if (byteArray.Length != GetSize())
@@ -633,11 +602,10 @@ namespace Shared.GameFormats.WWise.Hirc.V136
         }
     }
 
-
     public class StateChunk
     {
-        public List<AkStateGroupChunk> StateChunks { get; set; } = new List<AkStateGroupChunk>();
-        public List<AkStatePropertyInfo> StateProps { get; set; } = new List<AkStatePropertyInfo>();
+        public List<AkStateGroupChunk> StateChunks { get; set; } = [];
+        public List<AkStatePropertyInfo> StateProps { get; set; } = [];
 
         public static StateChunk Create(ByteChunk chunk)
         {
@@ -652,7 +620,7 @@ namespace Shared.GameFormats.WWise.Hirc.V136
             return instance;
         }
 
-        public uint GetSize() => 2;
+        public static uint GetSize() => 2;
 
         public byte[] GetAsByteArray()
         {
@@ -670,18 +638,17 @@ namespace Shared.GameFormats.WWise.Hirc.V136
         }
     }
 
-
     public class AkStateGroupChunk
     {
-        public uint ulStateGroupID { get; set; }
-        public byte eStateSyncType { get; set; }
-        public List<AkState> States { get; set; } = new List<AkState>();
+        public uint UlStateGroupId { get; set; }
+        public byte EStateSyncType { get; set; }
+        public List<AkState> States { get; set; } = [];
 
         public static AkStateGroupChunk Create(ByteChunk chunk)
         {
             var instance = new AkStateGroupChunk();
-            instance.ulStateGroupID = chunk.ReadUInt32();
-            instance.eStateSyncType = chunk.ReadByte();
+            instance.UlStateGroupId = chunk.ReadUInt32();
+            instance.EStateSyncType = chunk.ReadByte();
 
             var count = chunk.ReadByte();
             for (var i = 0; i < count; i++)
@@ -693,42 +660,40 @@ namespace Shared.GameFormats.WWise.Hirc.V136
 
     public class AkState
     {
-        public uint ulStateID { get; set; }
-        public uint ulStateInstanceID { get; set; }
+        public uint UlStateId { get; set; }
+        public uint UlStateInstanceId { get; set; }
         public static AkState Create(ByteChunk chunk)
         {
             var instance = new AkState();
-            instance.ulStateID = chunk.ReadUInt32();
-            instance.ulStateInstanceID = chunk.ReadUInt32();
+            instance.UlStateId = chunk.ReadUInt32();
+            instance.UlStateInstanceId = chunk.ReadUInt32();
             return instance;
         }
     }
 
-
-    public class InitialRTPC
+    public class InitialRtpc
     {
-        public List<RTPC> RTPCList { get; set; } = new List<RTPC>();
+        public List<Rtpc> RtpcList { get; set; } = [];
 
-        public static InitialRTPC Create(ByteChunk chunk)
+        public static InitialRtpc Create(ByteChunk chunk)
         {
-            var instance = new InitialRTPC();
+            var instance = new InitialRtpc();
             var count = chunk.ReadUShort();
             for (var i = 0; i < count; i++)
-                instance.RTPCList.Add(RTPC.Create(chunk));
+                instance.RtpcList.Add(Rtpc.Create(chunk));
 
             return instance;
         }
 
-
-        public uint GetSize() => 2;
+        public static uint GetSize() => 2;
 
         public byte[] GetAsByteArray()
         {
-            if (RTPCList.Count != 0)
+            if (RtpcList.Count != 0)
                 throw new NotImplementedException();
 
             using var memStream = new MemoryStream();
-            memStream.Write(ByteParsers.UShort.EncodeValue((ushort)RTPCList.Count, out _));
+            memStream.Write(ByteParsers.UShort.EncodeValue((ushort)RtpcList.Count, out _));
             var byteArray = memStream.ToArray();
             if (byteArray.Length != GetSize())
                 throw new Exception("Invalid size");
@@ -736,43 +701,43 @@ namespace Shared.GameFormats.WWise.Hirc.V136
         }
     }
 
-    public class RTPC
+    public class Rtpc
     {
-        public uint RTPCID { get; set; }
-        public byte rtpcType { get; set; }
-        public byte rtpcAccum { get; set; }
-        public byte ParamID { get; set; }
-        public uint rtpcCurveID { get; set; }
-        public byte eScaling { get; set; }
-        public List<AkRTPCGraphPoint> pRTPCMgr { get; set; } = new List<AkRTPCGraphPoint>();
+        public uint RtpcId { get; set; }
+        public byte RtpcType { get; set; }
+        public byte RtpcAccum { get; set; }
+        public byte ParamId { get; set; }
+        public uint RtpcCurveId { get; set; }
+        public byte EScaling { get; set; }
+        public List<AkRtpcGraphPoint> PRtpcMgr { get; set; } = [];
 
-        public static RTPC Create(ByteChunk chunk)
+        public static Rtpc Create(ByteChunk chunk)
         {
-            var instance = new RTPC();
-            instance.RTPCID = chunk.ReadUInt32();
-            instance.rtpcType = chunk.ReadByte();
-            instance.rtpcAccum = chunk.ReadByte();
-            instance.ParamID = chunk.ReadByte();
-            instance.rtpcCurveID = chunk.ReadUInt32();
-            instance.eScaling = chunk.ReadByte();
+            var instance = new Rtpc();
+            instance.RtpcId = chunk.ReadUInt32();
+            instance.RtpcType = chunk.ReadByte();
+            instance.RtpcAccum = chunk.ReadByte();
+            instance.ParamId = chunk.ReadByte();
+            instance.RtpcCurveId = chunk.ReadUInt32();
+            instance.EScaling = chunk.ReadByte();
 
             var count = chunk.ReadUShort();
             for (var i = 0; i < count; i++)
-                instance.pRTPCMgr.Add(AkRTPCGraphPoint.Create(chunk));
+                instance.PRtpcMgr.Add(AkRtpcGraphPoint.Create(chunk));
 
             return instance;
         }
     }
 
-    public class AkRTPCGraphPoint
+    public class AkRtpcGraphPoint
     {
         public float From { get; set; }
         public float To { get; set; }
         public uint Interp { get; set; }
 
-        public static AkRTPCGraphPoint Create(ByteChunk chunk)
+        public static AkRtpcGraphPoint Create(ByteChunk chunk)
         {
-            var instance = new AkRTPCGraphPoint();
+            var instance = new AkRtpcGraphPoint();
             instance.From = chunk.ReadSingle();
             instance.To = chunk.ReadSingle();
             instance.Interp = chunk.ReadUInt32();
@@ -783,15 +748,15 @@ namespace Shared.GameFormats.WWise.Hirc.V136
     public class AkStatePropertyInfo
     {
         public byte PropertyId { get; set; }
-        public byte accumType { get; set; }
-        public byte inDb { get; set; }
+        public byte AccumType { get; set; }
+        public byte InDb { get; set; }
 
         public static AkStatePropertyInfo Create(ByteChunk chunk)
         {
             var instance = new AkStatePropertyInfo();
             instance.PropertyId = chunk.ReadByte();
-            instance.accumType = chunk.ReadByte();
-            instance.inDb = chunk.ReadByte();
+            instance.AccumType = chunk.ReadByte();
+            instance.InDb = chunk.ReadByte();
             return instance;
         }
     }

--- a/Shared/GameFiles/WWise/HircItem.cs
+++ b/Shared/GameFiles/WWise/HircItem.cs
@@ -13,7 +13,6 @@ namespace Shared.GameFormats.WWise
         public bool IsCaHircItem { get; set; }
         public uint ByteIndexInFile { get; set; }
         public bool HasError { get; set; } = true;
-
         public HircType Type { get; set; }
         public uint Size { get; set; }
         public uint Id { get; set; }

--- a/Shared/GameFiles/WWise/Stid/StidParser.cs
+++ b/Shared/GameFiles/WWise/Stid/StidParser.cs
@@ -4,13 +4,11 @@ namespace Shared.GameFormats.WWise.Stid
 {
     public class StidParser
     {
-        public BnkChunkHeader Parse(string fileName, ByteChunk chunk, ParsedBnkFile soundDb)
+        public static BnkChunkHeader Parse(string fileName, ByteChunk chunk, ParsedBnkFile soundDb)
         {
             var chunckHeader = BnkChunkHeader.CreateFromBytes(chunk);
             chunk.Index += (int)chunckHeader.ChunkSize;
             return chunckHeader;
         }
     }
-
-
 }


### PR DESCRIPTION
Resolved naming violations within Wwise serialisation e.g Children_uIdx  --> ChildrenUIdx. I've only renamed things that were logic related, so haven't renamed enums as they directly correlate to Wwise bank decoding.