### PR TITLE
Updates and fixes for GFLT Import

### DIFF
--- a/Editors/ImportExportEditor/Editors.ImportExport/Common/ImageProcessor/IImageProcessor.cs
+++ b/Editors/ImportExportEditor/Editors.ImportExport/Common/ImageProcessor/IImageProcessor.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using DirectXTexNet;
+using Shared.Core.Settings;
+using Shared.GameFormats.RigidModel.Types;
+
+namespace Editors.ImportExport.Common.Interfaces
+{
+    public interface IImageProcessor
+    {
+        ScratchImage Transform(ScratchImage scratchImage);
+    }
+
+}

--- a/Editors/ImportExportEditor/Editors.ImportExport/Common/ImageProcessor/ImageProcessorFactory.cs
+++ b/Editors/ImportExportEditor/Editors.ImportExport/Common/ImageProcessor/ImageProcessorFactory.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Editors.ImportExport.Importing.Importers.PngToDds.Helpers.ImageProcessor;
+using Shared.Core.Settings;
+using Shared.GameFormats.RigidModel.Types;
+
+namespace Editors.ImportExport.Common.Interfaces
+{
+    public static class ImageProcessorFactory
+    {
+        private static readonly Dictionary<TextureType, IImageProcessor> _textureAndGameTypeToTranformer = new Dictionary<TextureType, IImageProcessor>()
+        {
+             {TextureType.Diffuse, new DefaultImageProcessor() },
+             {TextureType.MaterialMap, new BlenderToWH3MaterialMapProcessor() },
+             {TextureType.BaseColour, new DefaultImageProcessor() },
+             {TextureType.Normal, new BlueToOrangeNormalMapProcessor() }
+        };
+
+        public static IImageProcessor CreateImageProcessor(TextureType textureType)
+        {
+            if (_textureAndGameTypeToTranformer.TryGetValue(textureType, out var imageProcessor))
+            {                
+                return imageProcessor;
+            }
+
+            return new DefaultImageProcessor();
+        }
+    }
+}

--- a/Editors/ImportExportEditor/Editors.ImportExport/DependencyInjectionContainer.cs
+++ b/Editors/ImportExportEditor/Editors.ImportExport/DependencyInjectionContainer.cs
@@ -13,9 +13,11 @@ using Editors.ImportExport.Exporting.Presentation.RmvToGltf;
 using Editors.ImportExport.Importing;
 using Editors.ImportExport.Importing.Importers.GltfToRmv;
 using Editors.ImportExport.Importing.Importers.GltfToRmv.Helper;
+using Editors.ImportExport.Importing.Presentation;
 using Microsoft.Extensions.DependencyInjection;
 using Shared.Core.DependencyInjection;
 using Shared.Core.DevConfig;
+using Editors.ImportImport.Importing.Presentation.RmvToGltf;
 using Shared.Ui.BaseDialogs.PackFileTree.ContextMenu.External;
 
 namespace Editors.ImportExport
@@ -38,8 +40,14 @@ namespace Editors.ImportExport
             services.AddTransient<IDdsToNormalPngExporter, DdsToNormalPngExporter>();
             services.AddTransient<RmvToGltfExporter>();
 
+            // Importer ViewModels
+            RegisterWindow<ImportWindow>(services);
+            services.AddTransient<ImporterCoreViewModel>();
+            services.AddTransient<IImporterViewModel, RmvToGltfImporterViewModel>();
+
             // Importers
             services.AddTransient<GltfImporter>();
+            services.AddTransient<RmvMaterialBuilder>();
 
             // Image Save Helper
             services.AddScoped<IImageSaveHandler, SystemImageSaveHandler>();
@@ -57,7 +65,7 @@ namespace Editors.ImportExport
             services.AddTransient<IGltfSceneLoader, GltfSceneLoader>();
             services.AddTransient<GltfSkeletonBuilder>();
             services.AddTransient<GltfAnimationBuilder>();
-            
+
             RegisterAllAsInterface<IDeveloperConfiguration>(services, ServiceLifetime.Transient);
         }
     }

--- a/Editors/ImportExportEditor/Editors.ImportExport/DevConfig/Export_Karl.cs
+++ b/Editors/ImportExportEditor/Editors.ImportExport/DevConfig/Export_Karl.cs
@@ -39,7 +39,7 @@ namespace Editors.ImportExport.DevConfig
 
            Directory.CreateDirectory(destPath);
 
-           var settings = new RmvToGltfExporterSettings(meshPackFile, new List<PackFile>() { animPackFile },  destPath + "myKarl.gltf", true, true, true, true);
+           var settings = new RmvToGltfExporterSettings(meshPackFile, new List<PackFile>() { animPackFile },  destPath + "myKarl.gltf", true, true, true, true, true);
            _exporter.Export(settings);
        }
 

--- a/Editors/ImportExportEditor/Editors.ImportExport/Editors.ImportExport.csproj
+++ b/Editors/ImportExportEditor/Editors.ImportExport/Editors.ImportExport.csproj
@@ -17,6 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="DirectXTexNet" Version="1.0.7" />
     <PackageReference Include="SharpGLTF.Core" Version="1.0.3" />
     <PackageReference Include="SharpGLTF.Toolkit" Version="1.0.3" />
   </ItemGroup>

--- a/Editors/ImportExportEditor/Editors.ImportExport/Exporting/ExportFileContextMenuHelper.cs
+++ b/Editors/ImportExportEditor/Editors.ImportExport/Exporting/ExportFileContextMenuHelper.cs
@@ -1,5 +1,5 @@
-﻿using Editors.ImportExport.Exporting.Exporters;
-using Editors.ImportExport.Misc;
+﻿using Editors.ImportExport.Misc;
+using Editors.ImportExport.Exporting.Exporters;
 using Shared.Core.Events;
 using Shared.Core.PackFiles.Models;
 using Shared.Core.Settings;

--- a/Editors/ImportExportEditor/Editors.ImportExport/Exporting/Exporters/RmvToGltf/Helpers/GltfMeshBuilder.cs
+++ b/Editors/ImportExportEditor/Editors.ImportExport/Exporting/Exporters/RmvToGltf/Helpers/GltfMeshBuilder.cs
@@ -1,4 +1,5 @@
-﻿using System.Numerics;
+﻿using System.IO;
+using System.Numerics;
 using Editors.ImportExport.Common;
 using Shared.GameFormats.RigidModel;
 using Shared.GameFormats.RigidModel.Vertex;
@@ -120,7 +121,16 @@ namespace Editors.ImportExport.Exporting.Exporters.RmvToGltf.Helpers
                   .WithAlpha(AlphaMode.MASK);
 
             foreach (var texture in texturesForModel)
+            {
                 material.WithChannelImage(texture.GlftTexureType, texture.SystemFilePath);
+
+                var channel = material.UseChannel(texture.GlftTexureType);
+                if (channel?.Texture?.PrimaryImage != null) 
+                {
+                    // Set SharpGLTF to re-resave textures with specified paths, default behavior is texturePath = "{folder}\meshName{counter}.png"
+                    channel.Texture.PrimaryImage.AlternateWriteFileName = Path.GetFileName(texture.SystemFilePath);
+                }                               
+            }
 
             return material;
         }

--- a/Editors/ImportExportEditor/Editors.ImportExport/Exporting/Exporters/RmvToGltf/Helpers/GltfSkeletonBuilder.cs
+++ b/Editors/ImportExportEditor/Editors.ImportExport/Exporting/Exporters/RmvToGltf/Helpers/GltfSkeletonBuilder.cs
@@ -1,6 +1,5 @@
 ﻿using System.Numerics;
 using Editors.ImportExport.Common;
-using Editors.ImportExport.Exporting.Exporters.GltfSkeleton;
 using Editors.Shared.Core.Services;
 using GameWorld.Core.Animation;
 using GameWorld.Core.SceneNodes;
@@ -22,14 +21,14 @@ namespace Editors.ImportExport.Exporting.Exporters.RmvToGltf.Helpers
 
         public GltfSkeletonBuilder(IPackFileService packFileService)
         {
-            _packFileService = packFileService;            
+            _packFileService = packFileService;
         }
 
         public ProcessedGltfSkeleton CreateSkeleton(AnimationFile skeletonAnimFile, ModelRoot outputScene, RmvToGltfExporterSettings settings)
-        {           
+        {
             var gltfSkeleton = CreateSkeleton(outputScene, skeletonAnimFile, settings.MirrorMesh);
-                        
-            return gltfSkeleton;            
+
+            return gltfSkeleton;
         }
 
         ProcessedGltfSkeleton CreateSkeleton(ModelRoot outputScene, AnimationFile animSkeletonFil, bool doMirror)
@@ -48,8 +47,8 @@ namespace Editors.ImportExport.Exporting.Exporters.RmvToGltf.Helpers
             var outputGltfBindings = new List<(Node node, Matrix4x4 invMatrix)>();
 
             var scene = outputScene.UseScene("default");
-
-            scene.CreateNode($"//skeleton//{animSkeletonFil.Header.SkeletonName.ToLower()}");
+            
+            AddSkeletonIdNodeToScene(animSkeletonFil, scene);
 
             var parentIdToGltfNode = new Dictionary<int, Node>();
             parentIdToGltfNode[-1] = scene.CreateNode(""); // bones with no parent will be children of the scene
@@ -58,7 +57,7 @@ namespace Editors.ImportExport.Exporting.Exporters.RmvToGltf.Helpers
             {
                 var parentNode = parentIdToGltfNode[animSkeletonFil.Bones[boneIndex].ParentId];
                 if (parentNode == null)
-                    throw new Exception($"Parent Node not found for boneIndex={boneIndex}");
+                    throw new Exception($"Parent Node cannot be null. boneIndex={boneIndex}");
 
                 parentIdToGltfNode[boneIndex] = parentNode.CreateNode(animSkeletonFil.Bones[boneIndex].Name);
 
@@ -74,7 +73,10 @@ namespace Editors.ImportExport.Exporting.Exporters.RmvToGltf.Helpers
 
             return new ProcessedGltfSkeleton() { Data = outputGltfBindings };
         }
-
-
+       
+        private static void AddSkeletonIdNodeToScene(AnimationFile animSkeletonFil, Scene scene)
+        {
+            scene.CreateNode($"//skeleton//{animSkeletonFil.Header.SkeletonName.ToLower()}");
+        }
     }
 }

--- a/Editors/ImportExportEditor/Editors.ImportExport/Exporting/Exporters/RmvToGltf/Helpers/GltfTextureHandler.cs
+++ b/Editors/ImportExportEditor/Editors.ImportExport/Exporting/Exporters/RmvToGltf/Helpers/GltfTextureHandler.cs
@@ -28,6 +28,9 @@ namespace Editors.ImportExport.Exporting.Exporters.RmvToGltf.Helpers
         {
             var output = new List<TextureResult>();
 
+            if (!settings.ExportMaterials)
+                return output;
+
             var exportedTextures = new Dictionary<string, string>();    // To avoid exporting same texture multiple times
 
             int lodICounnt = 1;

--- a/Editors/ImportExportEditor/Editors.ImportExport/Exporting/Exporters/RmvToGltf/Helpers/SkeletalAnimationMath.cs
+++ b/Editors/ImportExportEditor/Editors.ImportExport/Exporting/Exporters/RmvToGltf/Helpers/SkeletalAnimationMath.cs
@@ -1,8 +1,10 @@
 ﻿using Editors.ImportExport.Common;
 using Microsoft.Xna.Framework;
 using Shared.GameFormats.Animation;
+using SharpGLTF.Animations;
+using SharpGLTF.Schema2;
 
-namespace Editors.ImportExport.Exporting.Exporters.GltfSkeleton
+namespace Editors.ImportExport.Exporting.Exporters.RmvToGltf.Helpers
 {
     public class TransformData
     {
@@ -32,7 +34,51 @@ namespace Editors.ImportExport.Exporting.Exporters.GltfSkeleton
             }
         }
     }
+    public class GltfAnimationTrackSampler
+    {
+        static public Vector3 SampleTranslation(ModelRoot model, string boneName, float time)
+        {
+            // Access the first animation
+            var animation = model.LogicalAnimations[0];
 
+            // Access the first node
+            var node = model.LogicalNodes.FirstOrDefault(n => n.Name.ToLower() == boneName.ToLower());
+
+            if (node == null)
+            {
+                throw new Exception("Error, Unexpected, Node not found");
+            }
+
+            // Get the translation sampler for the node
+            var translationSampler = animation.FindTranslationChannel(node).GetTranslationSampler().CreateCurveSampler();            
+
+            var translationVector = translationSampler.GetPoint(time);
+
+            return GlobalSceneTransforms.FlipVector(translationVector, true);
+        }
+
+        static public Quaternion SampleQuaternion(ModelRoot model, string boneName, float time)
+        {
+            // Access the first animation
+            var animation = model.LogicalAnimations[0];
+
+            // Access the first nodef
+            var node = model.LogicalNodes.FirstOrDefault(n => n.Name.ToLower() == boneName.ToLower());
+
+            if (node == null)
+            {
+                throw new Exception("Error, Unexpected, Node not found");
+            }
+
+            // Get the translation sampler for the node 
+            var quaternionSampler = animation.FindRotationChannel(node).GetRotationSampler().CreateCurveSampler();
+
+            var outQuaternion = quaternionSampler.GetPoint(time);
+
+            return GlobalSceneTransforms.FlipQuaternion(outQuaternion, true);
+        }
+
+    }
     internal class FramePoseMatrixCalculator
     {
         private readonly AnimationFile _animationFile;
@@ -83,13 +129,13 @@ namespace Editors.ImportExport.Exporting.Exporters.GltfSkeleton
                 throw new Exception($"No anim parts! Bone Count: {file.Bones.Length}");
 
             if (file.AnimationParts[0].DynamicFrames.Count == 0)
-              throw new Exception($"No anim frames, in part 0!  Bone Count: {file.Bones.Length}, Anim Parts Count: {file.AnimationParts.Count}");                    
+                throw new Exception($"No anim frames, in part 0!  Bone Count: {file.Bones.Length}, Anim Parts Count: {file.AnimationParts.Count}");
 
             if (file.AnimationParts[0].DynamicFrames[0].Quaternion.Count != file.Bones.Length)
-                throw new Exception($"Not a valid skeleton file, doesn't contain quaternion values for all bones! Quat count frame 0: {file.AnimationParts[0].DynamicFrames[0].Quaternion.Count}, Bone count {file.Bones.Length}");            
-            
+                throw new Exception($"Not a valid skeleton file, doesn't contain quaternion values for all bones! Quat count frame 0: {file.AnimationParts[0].DynamicFrames[0].Quaternion.Count}, Bone count {file.Bones.Length}");
+
             if (file.AnimationParts[0].DynamicFrames[0].Transforms.Count != file.Bones.Length)
-                throw new Exception($"Not a valid skeleton file, doesn't contain translation values for all bones! Trans count frame 0: {file.AnimationParts[0].DynamicFrames[0].Transforms.Count}, Bone count {file.Bones.Length}");                        
+                throw new Exception($"Not a valid skeleton file, doesn't contain translation values for all bones! Trans count frame 0: {file.AnimationParts[0].DynamicFrames[0].Transforms.Count}, Bone count {file.Bones.Length}");
         }
 
         private void RebuildSkeletonGlobalMatrices(bool doMirror)
@@ -104,7 +150,7 @@ namespace Editors.ImportExport.Exporting.Exporters.GltfSkeleton
                 _worldTransform[boneIndex] = transform;
             }
 
-            for (var i = 0; i < _worldTransform.Length; i++) 
+            for (var i = 0; i < _worldTransform.Length; i++)
             {
                 var parentIndex = _animationFile.Bones[i].ParentId;
 

--- a/Editors/ImportExportEditor/Editors.ImportExport/Exporting/Exporters/RmvToGltf/RmvToGltfExporter.cs
+++ b/Editors/ImportExportEditor/Editors.ImportExport/Exporting/Exporters/RmvToGltf/RmvToGltfExporter.cs
@@ -1,4 +1,5 @@
 ﻿using System.Windows;
+using Editors.ImportExport.Common;
 using Editors.ImportExport.Exporting.Exporters.RmvToGltf.Helpers;
 using Editors.ImportExport.Misc;
 using GameWorld.Core.Services;
@@ -66,9 +67,10 @@ namespace Editors.ImportExport.Exporting.Exporters.RmvToGltf
                     gltfSkeleton = _gltfSkeletonBuilder.CreateSkeleton(skeletonAnimFile, outputScene, settings);
                     _gltfAnimationBuilder.Build(skeletonAnimFile, settings, gltfSkeleton, outputScene);
                 }
-            }
-
-            var textures = _gltfTextureHandler.HandleTextures(rmv2, settings);
+            }                       
+            
+            var textures = _gltfTextureHandler.HandleTextures(rmv2, settings);            
+            
             var meshes = _gltfMeshBuilder.Build(rmv2, textures, settings);
 
             _logger.Here().Information($"MeshCount={meshes.Count()} TextureCount={textures.Count()} Skeleton={gltfSkeleton?.Data.Count}");

--- a/Editors/ImportExportEditor/Editors.ImportExport/Exporting/Exporters/RmvToGltf/RmvToGltfExporterSettings.cs
+++ b/Editors/ImportExportEditor/Editors.ImportExport/Exporting/Exporters/RmvToGltf/RmvToGltfExporterSettings.cs
@@ -7,6 +7,7 @@ namespace Editors.ImportExport.Exporting.Exporters.RmvToGltf
         PackFile InputModelFile,
         List<PackFile> InputAnimationFiles,
         string OutputPath,
+        bool ExportMaterials, 
         bool ConvertMaterialTextureToBlender,
         bool ConvertNormalTextureToBlue,
         bool ExportAnimations,

--- a/Editors/ImportExportEditor/Editors.ImportExport/Exporting/Presentation/RmvToGltf/RmvToGltfExporterViewModel.cs
+++ b/Editors/ImportExportEditor/Editors.ImportExport/Exporting/Presentation/RmvToGltf/RmvToGltfExporterViewModel.cs
@@ -28,7 +28,7 @@ namespace Editors.ImportExport.Exporting.Presentation.RmvToGltf
 
         public void Execute(PackFile exportSource, string outputPath, bool generateImporter)
         {
-            var settings = new RmvToGltfExporterSettings(exportSource, [], outputPath, ConvertMaterialTextureToBlender, ConvertNormalTextureToBlue, ExportAnimations, true);
+            var settings = new RmvToGltfExporterSettings(exportSource, [], outputPath, ExportTextures, ConvertMaterialTextureToBlender, ConvertNormalTextureToBlue, ExportAnimations, true);
             _exporter.Export(settings);
         }
     }

--- a/Editors/ImportExportEditor/Editors.ImportExport/Importing/ImportFIleContextMenuHelper.cs
+++ b/Editors/ImportExportEditor/Editors.ImportExport/Importing/ImportFIleContextMenuHelper.cs
@@ -1,5 +1,8 @@
 ﻿using System.IO;
+using Editors.ImportExport.Exporting.Exporters;
+using Editors.ImportExport.Misc;
 using Shared.Core.Events;
+using Shared.Core.PackFiles.Models;
 using Shared.Core.Settings;
 using Shared.Ui.BaseDialogs.PackFileTree.ContextMenu.External;
 using TreeNode = Shared.Ui.BaseDialogs.PackFileTree.TreeNode;
@@ -8,18 +11,21 @@ namespace Editors.ImportExport.Importing
 {
     public class ImportFileContextMenuHelper : IImportFileContextMenuHelper
     {
+
         private readonly IUiCommandFactory _uiCommandFactory;
+        private readonly IEnumerable<IExporterViewModel> _exporterViewModels;
         private readonly ApplicationSettingsService _applicationSettings;
 
-        public ImportFileContextMenuHelper(IUiCommandFactory uiCommandFactory, ApplicationSettingsService applicationSettings)
+        public ImportFileContextMenuHelper(IUiCommandFactory uiCommandFactory, IEnumerable<IExporterViewModel> exporterViewModels, ApplicationSettingsService applicationSettings)
         {
             _uiCommandFactory = uiCommandFactory;
+            _exporterViewModels = exporterViewModels;
             _applicationSettings = applicationSettings;
         }
 
-        public bool CanImportFile(string filePath)
+        public bool CanImportFile(PackFile filePath)
         {
-            if (Path.GetExtension(filePath.ToUpperInvariant()) == new string(".gltf").ToUpperInvariant()) // mess to make sure the extension is case insensitive
+            if (FileExtensionHelper.IsGltfFile(filePath.Name)) // mess to make sure the extension is case insensitive
             {
                 return true;
             }
@@ -28,6 +34,6 @@ namespace Editors.ImportExport.Importing
         }
 
         public void ShowDialog(TreeNode clickedNode) =>
-                _uiCommandFactory.Create<DisplayImportFileToolCommand>().Execute(clickedNode);
+                _uiCommandFactory.Create<DisplayImportFileToolCommand>().Execute(clickedNode.FileOwner, clickedNode.GetFullPath());
     }
 }

--- a/Editors/ImportExportEditor/Editors.ImportExport/Importing/Importers/GltfToRmv/GltfImporter.cs
+++ b/Editors/ImportExportEditor/Editors.ImportExport/Importing/Importers/GltfToRmv/GltfImporter.cs
@@ -1,7 +1,12 @@
 ﻿using System.IO;
 using CommonControls.BaseDialogs.ErrorListDialog;
 using Editors.ImportExport.Importing.Importers.GltfToRmv.Helper;
+using Editors.ImportExport.Misc;
+using Editors.Shared.Core.Services;
+using GameWorld.Core.SceneNodes;
 using GameWorld.Core.Services;
+using Octokit;
+using Serilog;
 using Shared.Core.ErrorHandling;
 using Shared.Core.PackFiles;
 using Shared.Core.PackFiles.Models;
@@ -15,78 +20,156 @@ namespace Editors.ImportExport.Importing.Importers.GltfToRmv
 {
     public class GltfImporter
     {
+        private const string Value = "//skeleton//";
         private readonly IPackFileService _packFileService;
         private readonly IStandardDialogs _exceptionService;
+        private readonly ILogger _logger = Logging.Create<GltfImporter>();
         private readonly ISkeletonAnimationLookUpHelper _skeletonLookUpHelper;
+        private readonly RmvMaterialBuilder _materialBuilder;
 
-        public GltfImporter(IPackFileService packFileSerivce, IStandardDialogs exceptionService, ISkeletonAnimationLookUpHelper skeletonLookUpHelper)
+        public GltfImporter(IPackFileService packFileSerivce, IStandardDialogs exceptionService, ISkeletonAnimationLookUpHelper skeletonLookUpHelper, RmvMaterialBuilder materialBuilder)
         {
             _packFileService = packFileSerivce;
             _exceptionService = exceptionService;
             _skeletonLookUpHelper = skeletonLookUpHelper;
+            _materialBuilder = materialBuilder;
+        }
+
+        public ImportSupportEnum CanImportFile(PackFile file)
+        {
+            if (FileExtensionHelper.IsGltfFile(file.Name))
+                return ImportSupportEnum.HighPriority;
+
+            return ImportSupportEnum.NotSupported;
+        }
+
+        private RmvFile? ImportMeshes(GltfImporterSettings settings, ModelRoot modelRoot, AnimationFile? skeletonAnimFile, string skeletonName)
+        {
+            var importedFileName = GetImportedPackFileName(settings);
+
+            var rmv2File = RmvMeshBuilder.Build(settings, modelRoot, skeletonAnimFile, skeletonName);
+            if (rmv2File == null)
+                return null;
+
+            return rmv2File;
+        }
+
+        private void SaveRmvFileToPack(GltfImporterSettings settings, string importedFileName, RmvFile rmv2File)
+        {
+            var bytesRmv2 = ModelFactory.Create().Save(rmv2File);
+
+            var packFileImported = new PackFile(importedFileName, new MemorySource(bytesRmv2));
+            var newFile = new NewPackFileEntry(settings.DestinationPackPath, packFileImported);
+
+            _packFileService.AddFilesToPack(settings.DestinationPackFileContainer, [newFile]);
+        }
+
+        private void ImportMaterials(GltfImporterSettings settings, ModelRoot modelRoot, RmvFile rmv2File)
+        {
+            _materialBuilder.BuildRmvFileMaterials(settings, modelRoot, rmv2File);
+        }
+
+        private void ImportAnimations(GltfImporterSettings settings, ModelRoot modelRoot, AnimationFile? skeletonAnimFile, string skeletonName)
+        {
+            var fileName = Path.GetFileNameWithoutExtension(settings.InputGltfFile);
+            string importedFileName = $@"{fileName}.anim";
+
+            var animFile = AnimationBuilder.Build(new AnimationBuilderSettings(modelRoot, skeletonName, settings.AnimationKeysPerSecond, settings.DestinationPackFileContainer, settings.DestinationPackPath), skeletonAnimFile);
+
+            if (animFile != null)
+            {
+                var animBytes = AnimationFile.ConvertToBytes(animFile);
+                var packFileImported = new PackFile(importedFileName, new MemorySource(animBytes));
+                var newFile = new NewPackFileEntry(settings.DestinationPackPath, packFileImported);
+                _packFileService.AddFilesToPack(settings.DestinationPackFileContainer, [newFile]);
+            }
         }
 
         public void Import(GltfImporterSettings settings)
         {
+            if (!CreateModelRoot(settings, out var modelRoot))
+                return;
+
+            var skeletonData = GetSkeletonData(modelRoot);
+
+            var rmv2File = ImportMeshes(settings, modelRoot, skeletonData.skeletonAnimFile, skeletonData.skeletonName ?? "");
+            if (rmv2File == null)
+                throw new Exception($"Failed to import mesh, rmv2File == {rmv2File}");
+
+            if (settings.ImportMaterials)
+                ImportMaterials(settings, modelRoot, rmv2File);
+
+            if (settings.ImportAnimations)
+                ImportAnimations(settings, modelRoot, skeletonData.skeletonAnimFile, skeletonData.skeletonName ?? "");
+
+            if (settings.ImportMeshes)
+                SaveRmvFileToPack(settings, GetImportedPackFileName(settings), rmv2File);
+
+        }
+
+        private static bool CreateModelRoot(GltfImporterSettings settings, out ModelRoot? outModelRoot)
+        {
             ModelRoot? modelRoot = null;
-            try
+            try // use GLTF api to verify that all needed files are present
             {
+                var result = ModelRoot.Validate(settings.InputGltfFile);
                 modelRoot = ModelRoot.Load(settings.InputGltfFile);
             }
             catch (Exception ex)
             {
-                _exceptionService.ShowExceptionWindow(ex);
-                return;
+                var errorList = new ErrorList();
+                errorList.Error("GLTF Load Error, might not be valid GLTF file.", ex.Message);
+                ErrorListWindow.ShowDialog("Advanced Import Error", errorList, false);
+                outModelRoot = null;                
+                return false;
             }
 
-            var importedFileName = GetImportedPackFileName(settings);
-            
+            outModelRoot = modelRoot;
+            return true;
+        }
+
+        private (string? skeletonName, AnimationFile? skeletonAnimFile) GetSkeletonData(ModelRoot? modelRoot)
+        {
+            if (modelRoot == null)
+                throw new ArgumentException($"Invalid Input: {nameof(modelRoot)} == {modelRoot}");
+
             var skeletonName = FetchSkeletonIdStringFromScene(modelRoot);
+
             if (skeletonName == null)
-                throw new ArgumentNullException(nameof(skeletonName), "Fatal eroro: This shouldn't be null");
+            {
+                _logger.Information("Skeleton ID not found in scene, if the model loading is not rigged, then ignore this.");
+                return ("", null);
+            }
 
             AnimationFile? skeletonAnimFile = null;
-            if (skeletonName.Any())
+            if (skeletonName != null && skeletonName.Any())
             {
                 skeletonAnimFile = _skeletonLookUpHelper.GetSkeletonFileFromName(skeletonName);
-                                
+
                 if (skeletonAnimFile == null)
                 {
-                    var errorList = new ErrorList();                 
-                    errorList.Error("Skeleton Not Found", $"Skeleton named '{skeletonName}' could not be found\nHave you selected the correct game AND loaded all CA Pack Files?");                   
-                    
+                    var errorList = new ErrorList();
+                    errorList.Error("Skeleton Not Found", $"Skeleton named '{skeletonName}' could not be found\nHave you selected the correct game AND loaded all CA Pack Files?");
+
                     ErrorListWindow.ShowDialog("Skeleton Error", errorList);
 
-                    return;
+                    return (skeletonName = null, skeletonAnimFile = null);
                 }
             }
 
-            var rmv2File = RmvMeshBuilder.Build(settings, modelRoot, skeletonAnimFile, skeletonName);
-            var bytesRmv2 = ModelFactory.Create().Save(rmv2File);
-
-            var packFileImported = new PackFile(importedFileName, new MemorySource(bytesRmv2));
-
-            var newFile = new NewPackFileEntry(settings.DestinationPackPath, packFileImported);
-            _packFileService.AddFilesToPack(settings.DestinationPackFileContainer, [newFile]);
-            
+            return (skeletonName, skeletonAnimFile);
         }
 
-        private static string GetImportedPackFileName(GltfImporterSettings settings)
-        {
-            var fileName = Path.GetFileNameWithoutExtension(settings.InputGltfFile);
-            string importedFileName = $@"{fileName}.rigid_model_v2";
-
-            return importedFileName;
-        }
+        private static string GetImportedPackFileName(GltfImporterSettings settings) => Path.GetFileNameWithoutExtension(settings.InputGltfFile) + ".rigid_model_v2";
 
         private static string FetchSkeletonIdStringFromScene(ModelRoot modelRoot)
         {
-            var nodeSearchResult = modelRoot.LogicalNodes.Where(node => node.Name.StartsWith("//skeleton//"));
+            var nodeSearchResult = modelRoot.LogicalNodes.Where(node => node.Name.StartsWith(Value));
 
             if (nodeSearchResult == null || !nodeSearchResult.Any())
                 return "";
 
-            var skeletonName = nodeSearchResult.First().Name.TrimStart("//skeleton//".ToCharArray());
+            var skeletonName = nodeSearchResult.First().Name.TrimStart(Value.ToCharArray());
 
             return skeletonName.ToLower();
         }

--- a/Editors/ImportExportEditor/Editors.ImportExport/Importing/Importers/GltfToRmv/GltfImporterSettings.cs
+++ b/Editors/ImportExportEditor/Editors.ImportExport/Importing/Importers/GltfToRmv/GltfImporterSettings.cs
@@ -1,4 +1,5 @@
 ﻿using Shared.Core.PackFiles.Models;
+using Shared.Core.Settings;
 
 namespace Editors.ImportExport.Importing.Importers.GltfToRmv
 {
@@ -7,8 +8,13 @@ namespace Editors.ImportExport.Importing.Importers.GltfToRmv
         string InputGltfFile,
         string DestinationPackPath,
         PackFileContainer DestinationPackFileContainer,
-        bool ConvertNormalTextureToOrangeType,
+        GameTypeEnum SelectedGame,
+        bool ImportMeshes,        
+        bool ImportMaterials,
+        bool ConvertMaterialFromBlenderType,
+        bool ConvertNormalTextureFromBlueToOrangeType,
         bool ImportAnimations,
+        float AnimationKeysPerSecond,
         bool MirrorMesh
     );
 }

--- a/Editors/ImportExportEditor/Editors.ImportExport/Importing/Importers/GltfToRmv/Helper/AnimationBuilder.cs
+++ b/Editors/ImportExportEditor/Editors.ImportExport/Importing/Importers/GltfToRmv/Helper/AnimationBuilder.cs
@@ -1,0 +1,130 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using System.Text;
+using System.Threading.Tasks;
+using Shared.Core.ErrorHandling.Exceptions;
+using SharpGLTF.Schema2;
+using System.Windows;
+using Shared.Core.Services;
+using Shared.GameFormats.Animation;
+using Shared.Core.PackFiles.Models;
+using static Shared.GameFormats.Animation.AnimationFile;
+using Microsoft.Xna.Framework.Graphics;
+using System.Xml.Linq;
+using System.Security.Authentication.ExtendedProtection;
+using Editors.ImportExport.Exporting.Exporters.RmvToGltf.Helpers;
+using Shared.GameFormats.RigidModel.Transforms;
+using Editors.Shared.Core.Services;
+using System.Windows.Media;
+
+namespace Editors.ImportExport.Importing.Importers.GltfToRmv.Helper
+{
+    public record AnimationBuilderSettings(
+        ModelRoot modelRoot,
+        string skeletonName,
+        float keysPerSecond,
+        PackFileContainer packFileContainer,
+        string packPath
+    );
+
+    public class AnimationBuilder  
+    {        
+        static public AnimationFile? Build(AnimationBuilderSettings settings, AnimationFile skeletonAnimFile)
+        {
+            if (settings.modelRoot.LogicalAnimations.Count() == 0)
+                return null;
+
+            AnimationFile newAnimFile = new AnimationFile();
+
+            var animation = settings.modelRoot.LogicalAnimations[0];
+
+            var animationTime = animation.Duration;
+            var keyInterval = 1.0f / settings.keysPerSecond; // time between keys
+            var keyCount = (int)(animationTime / keyInterval); // number of keys
+            
+            newAnimFile.Header = new AnimationHeader()
+            {
+                Version = 7,    
+                FrameRate = settings.keysPerSecond,
+                SkeletonName = settings.skeletonName,
+
+                // TODO: this value is actually the time for the last key, not duration
+                // so, we subtract one "keytime" from the value.
+                AnimationTotalPlayTimeInSec = keyInterval * (float)(keyCount - 1)
+            };
+
+            newAnimFile.Bones = skeletonAnimFile.Bones;
+            newAnimFile.AnimationParts = new AnimationPart[1].ToList(); // ALLOCATE ONE PART
+            newAnimFile.AnimationParts[0] = new AnimationPart();
+            var part = newAnimFile.AnimationParts[0];
+
+            part.DynamicFrames = new List<Frame>();
+
+            DoQuantization(skeletonAnimFile, part);
+
+            float keyTime = 0.0f;
+            for (int i = 0; i < keyCount; i++)
+            {
+                var frame = new Frame();
+                FillFrame(settings, skeletonAnimFile, keyTime, frame);
+                part.DynamicFrames.Add(frame);
+                keyTime += keyInterval;
+            }
+
+            return newAnimFile;
+        }
+
+        private static void DoQuantization(AnimationFile skeletonAnimFile, AnimationPart part)
+        {
+            /*
+            -- TODO: add ANIM v6 quantization ---
+           
+            - which track are both constant and = bind pose?
+            - iterate through tracks, 
+                 - if track is constant and = bind pose, 
+                    - insert "-1" into the quantization list
+                        - don't store the track in the frame
+                        
+            -- TODO: add ANIM v7 quantization ---
+            - which track are both constant and which are = bind pose?
+            - iterate through tracks, 
+                 - if track is constant and = bind pose, 
+                    - insert "-1" into the quantization list
+                        - don't store the track in the frame
+                 - if constant but != bind pose
+                 - adds its value to const track(aka static frame)
+                 - in the quantization list, insert the index of the const track + 10000        
+            
+            */
+
+
+            // set the quantization settings to UNquantized
+            for (int i = 0; i < skeletonAnimFile.Bones.Length; i++)
+            {
+                part.TranslationMappings.Add(new AnimationBoneMapping(i));
+                part.RotationMappings.Add(new AnimationBoneMapping(i));
+            }
+        }
+
+        private static void FillFrame(AnimationBuilderSettings settings, AnimationFile skeletonAnimFile, float currentKeyTime, Frame frame)
+        {
+            RmvVector3[] translations = new RmvVector3[skeletonAnimFile.Bones.Length];
+            RmvVector4[] quaternions = new RmvVector4[skeletonAnimFile.Bones.Length];
+
+            foreach (var bone in skeletonAnimFile.Bones)
+            {
+                var translation = GltfAnimationTrackSampler.SampleTranslation(settings.modelRoot, bone.Name, currentKeyTime);
+                var quaternion = GltfAnimationTrackSampler.SampleQuaternion(settings.modelRoot, bone.Name, currentKeyTime);
+
+                // using the arrays with bone.id as index, makes sure sampled data is stored at the index
+                translations[bone.Id] = new RmvVector3(translation);
+                quaternions[bone.Id] = new RmvVector4(quaternion.X, quaternion.Y, quaternion.Z, quaternion.W);
+            }
+
+            frame.Transforms = translations.ToList();
+            frame.Quaternion = quaternions.ToList();
+        }
+    }
+}

--- a/Editors/ImportExportEditor/Editors.ImportExport/Importing/Importers/GltfToRmv/Helper/MeshWeightValidator.cs
+++ b/Editors/ImportExportEditor/Editors.ImportExport/Importing/Importers/GltfToRmv/Helper/MeshWeightValidator.cs
@@ -24,7 +24,10 @@ namespace Editors.ImportExport.Importing.Importers.GltfToRmv.Helper
             return true;
         }
         static public void ValidateVertexWeighting(CommonVertex v)
-        {            
+        {
+            if (v.WeightCount == 0)
+                throw new Exception("Error: Invalid weights, 1 of more null weights in weighted mesh");
+
             if (v.WeightCount != v.BoneWeight.Length || v.WeightCount != v.BoneIndex.Length)
                 throw new Exception("Error: Invalid Vertex Weight State");            
 
@@ -38,10 +41,8 @@ namespace Editors.ImportExport.Importing.Importers.GltfToRmv.Helper
 
             const float tolerance = 0.05f;
             if (weightSum < (1.0f - tolerance) || weightSum > (1.0f + tolerance))
-                throw new Exception("Error: sum of weights not 1.0f");
+                throw new Exception("Error: sum of weights not 1.0f");                        
                         
-            if (v.WeightCount == 0)                          
-                   throw new Exception("Error: Invalid weights, 1 of more null weights in weighted mesh");
         }
     }
 }

--- a/Editors/ImportExportEditor/Editors.ImportExport/Importing/Importers/GltfToRmv/Helper/RmvMaterialBuilder.cs
+++ b/Editors/ImportExportEditor/Editors.ImportExport/Importing/Importers/GltfToRmv/Helper/RmvMaterialBuilder.cs
@@ -1,0 +1,172 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Editors.ImportExport.Importing.Importers.PngToDds;
+using Shared.Core.PackFiles;
+using Shared.Core.PackFiles.Models;
+using Shared.Core.Services;
+using Shared.Core.Settings;
+using Shared.GameFormats.RigidModel;
+using Shared.GameFormats.RigidModel.Types;
+using SharpDX.DirectWrite;
+using SharpGLTF.Schema2;
+using TextureType = Shared.GameFormats.RigidModel.Types.TextureType;
+using Editors.ImportExport.Importing.Importers.GltfToRmv.Helper;
+using Microsoft.VisualBasic;
+
+namespace Editors.ImportExport.Importing.Importers.GltfToRmv.Helper
+{
+    // TODO: MOVE THIS TO A SHARED LOCATION
+    public class TextureTypeHelper
+    {
+        static private readonly Dictionary<string, (TextureType texutureType, string namePostFix)> _stringIdToTextureType = new Dictionary<string, (TextureType, string)>()
+            {
+                {"BaseColor", (TextureType.BaseColour, "base_colour")},
+                {"Normal", (TextureType.Normal, "normal")},
+                {"MetallicRoughness", (TextureType.MaterialMap, "material_map")},
+                {"Diffuse", (TextureType.Diffuse, "diffuse")},
+                {"Specular", (TextureType.Specular, "specular")},
+                {"Glossiness", (TextureType.Gloss, "gloss_map") }
+            };
+
+        static public bool GetRmvTextureTypeFromGltfIdString(string textureTypeString, out TextureType outTextureType, out string postFix)
+        {
+            if (_stringIdToTextureType.TryGetValue(textureTypeString, out var textureType))
+            {
+                outTextureType = textureType.texutureType;
+                postFix = textureType.namePostFix; 
+                return true;
+            }
+
+            outTextureType = TextureType.Diffuse;
+            postFix = "diffuse";
+            return false;
+        }
+    }
+    public class RmvMaterialBuilder
+    {
+        private readonly IPackFileService _packFileService;
+        private readonly IStandardDialogs _exceptionService;        
+
+        public RmvMaterialBuilder(IPackFileService packFileSerivce, IStandardDialogs exceptionService)
+        {
+            _packFileService = packFileSerivce;
+            _exceptionService = exceptionService;
+        }
+
+        public void BuildRmvFileMaterials(GltfImporterSettings settings, SharpGLTF.Schema2.ModelRoot modelRoot, RmvFile rmvFile)
+        {
+            ValidateInput_BuildRmvFileMaterials(modelRoot, rmvFile);
+
+            for (int i = 0; i < modelRoot.LogicalMeshes.Count; i++)
+            {
+                BuildRmvModelMaterial(
+                    settings,
+                    modelRoot.LogicalMeshes[i],
+                    (rmvFile.ModelList.Any() && rmvFile.ModelList[0].Any())
+                    ?
+                    rmvFile.ModelList[0][i]
+                    :
+                    null
+                );
+            }
+
+            rmvFile.RecalculateOffsets();
+        }
+
+        private void BuildRmvModelMaterial(GltfImporterSettings settings, Mesh mesh, RmvModel rmvModel)
+        {
+            if (!ValidateInput_BuildRmvModelMaterial(mesh)) return;
+
+            var primitive = mesh.Primitives.First();
+            var gltfMaterial = primitive.Material;
+
+            foreach (var itText in gltfMaterial.Channels)
+            {
+                if (itText.Texture == null) continue;
+
+                var texPath = itText.Texture.PrimaryImage.Content.SourcePath;
+                if (!TextureTypeHelper.GetRmvTextureTypeFromGltfIdString(
+                    itText.Key,
+                    out var textureType,
+                    out var postFixString)) continue; // gltf string id doesn't match any of the rmv texture types
+
+                var gameType = settings.SelectedGame;                
+                
+                var texturePackFolder = GetTexturePackFolder(settings, mesh.Name, postFixString);
+                var DEBUG___textureName = itText.Texture.PrimaryImage.Name;
+
+                // import texture PNG -> DDS
+                var ddsPackFile = PngToDdsImporter.Import(texPath, textureType, gameType, Path.GetFileName(texturePackFolder));
+
+                rmvModel.Material.SetTexture(textureType, texturePackFolder);
+
+                // make sure we don't add the same file to .pack more the once, as several meshes, may use the same texture, 
+                if (!settings.DestinationPackFileContainer.FileList.ContainsKey(texturePackFolder))
+                {
+                    var newFile = new NewPackFileEntry(Path.GetDirectoryName(texturePackFolder) ?? "", ddsPackFile);
+                    _packFileService.AddFilesToPack(settings.DestinationPackFileContainer, [newFile]);
+                }
+
+            }
+        }
+
+        private static string GetTexturePackFolder(GltfImporterSettings settings, string meshName, string postFixString)
+        {
+            // set file name
+            var textureNameBase = meshName.Any() ? meshName : Path.GetFileNameWithoutExtension(settings.InputGltfFile);
+            var textureFileName = @$"{textureNameBase} {(postFixString.Any() ? @$"_{postFixString}.dds" : ".dds")}";
+
+            var texturePackFolder = settings.DestinationPackPath + @"\tex";
+            var textureFullPackPath = @$"{texturePackFolder}\{textureFileName}";
+
+            return textureFullPackPath;
+        }
+
+        private static void ValidateInput_BuildRmvFileMaterials(ModelRoot modelRoot, RmvFile rmvFile)
+        {
+            if (modelRoot == null)
+                throw new ArgumentNullException(nameof(modelRoot), "Invalid Scene: ModelRoot can't be null");
+
+            if (modelRoot.LogicalNodes == null)
+                throw new ArgumentNullException(nameof(modelRoot), "Invalid Scene: root.LogicalNodes can't be null");
+
+            if (!modelRoot.LogicalNodes.Any())
+                throw new Exception("Invalid Scene: no (logical) nodes");
+
+            if (!rmvFile.ModelList.Any())
+                throw new Exception("ERROR: unexpected not meshes in rmv2 file struct");
+
+            if (rmvFile.ModelList[0].Length != modelRoot.LogicalMeshes.Count)
+                throw new Exception("ERROR: unexpected rmv2 mesh count mismatch");
+        }
+
+        private static bool ValidateInput_BuildRmvModelMaterial(Mesh mesh)
+        {
+            if (mesh == null)
+                throw new ArgumentNullException(nameof(mesh), "Invalid Mesh: Mesh can't be null");
+
+            if (mesh.Primitives == null || !mesh.Primitives.Any())
+                throw new Exception($"Invalid Mesh: No Primitives found in mesh. Primitives.Count = {mesh.Primitives?.Count}");
+
+            var primitive = mesh.Primitives.First();
+
+            if (primitive == null)
+                throw new Exception("Invalid Mesh: primitive[0] can't be null ");
+
+            var gltfMaterial = primitive.Material;
+
+            if (gltfMaterial == null)
+                return false;
+            
+            if (gltfMaterial.Channels == null || !gltfMaterial.Channels.Any())
+                return false;
+
+            return true;
+        }
+    }
+}
+

--- a/Editors/ImportExportEditor/Editors.ImportExport/Importing/Importers/PngToDds/Helpers/ColorChannels.cs
+++ b/Editors/ImportExportEditor/Editors.ImportExport/Importing/Importers/PngToDds/Helpers/ColorChannels.cs
@@ -1,0 +1,107 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics.PackedVector;
+using SharpDX.MediaFoundation;
+
+namespace Editors.ImportExport.Importing.Importers.PngToDds.Helpers
+{
+    public class ColorChannels
+    {
+        public static byte[] PtrToBytes(IntPtr ptr, int index, int size)
+        {
+            byte[] bytes = new byte[size];
+            Marshal.Copy(ptr, bytes, index, size);
+            return bytes;
+        }
+
+        public static void BytesToPtr(byte[] bytes, int index, IntPtr ptr)
+        {
+            Marshal.Copy(bytes, index, ptr, bytes.Length);
+        }
+
+        public static void GammaRGBA(ref byte r, ref byte g, ref byte b, ref byte a, float gamma)
+        {
+            var rgbaFloat = new Vector4((float)r, (float)g, (float)b, (float)a) / 255.0f;
+
+            r = (byte)(Math.Pow(rgbaFloat.X, gamma) * 255.0f);
+            g = (byte)(Math.Pow(rgbaFloat.Y, gamma) * 255.0f);
+            b = (byte)(Math.Pow(rgbaFloat.Z, gamma) * 255.0f);
+            a = (byte)(Math.Pow(rgbaFloat.W, gamma) * 255.0f);
+        }
+
+        public static byte GammaComponent(byte c, float gamma)
+        {           
+            var processed = (byte) (Math.Pow( ((double)c/255.0f ), gamma) * 255.0f);
+
+            return processed;
+        }
+
+
+
+        public float gamma_accurate_component(float linear_val)
+        {
+            const float srgb_gamma_ramp_inflection_point = 0.0031308f;
+
+            if (linear_val <= srgb_gamma_ramp_inflection_point)
+            {
+                return 12.92f * linear_val;
+            }
+            else
+            {
+                const float a = 0.055f;
+
+                return (float)((1.0 + a) * Math.Pow(linear_val, 1.0f / 2.4f)) - a;
+            }
+        }
+
+
+        public nint Value { get; set; }
+
+        public byte[] Channels { get; set; }
+
+        public byte this[int index]
+        {
+            get
+            {
+                if (index < 0 || index > 3)
+                    throw new IndexOutOfRangeException("Index must be between 0 and 3.");
+
+                byte[] intBytes = BitConverter.GetBytes(Value);
+                if (BitConverter.IsLittleEndian)
+                    Array.Reverse(intBytes);
+
+                return intBytes[index];
+            }
+            set
+            {
+                if (index < 0 || index > 3)
+                    throw new IndexOutOfRangeException("Index must be between 0 and 3.");
+
+                byte[] intBytes = BitConverter.GetBytes(Value);
+                if (BitConverter.IsLittleEndian)
+                    Array.Reverse(intBytes);
+
+                intBytes[index] = value;
+
+                if (BitConverter.IsLittleEndian)
+                    Array.Reverse(intBytes);
+
+                Value = BitConverter.ToInt32(intBytes, 0);
+            }
+        }
+
+        public ColorChannels(nint rgbaValue)
+        {
+            Value = rgbaValue;
+
+
+
+        }
+    }
+}

--- a/Editors/ImportExportEditor/Editors.ImportExport/Importing/Importers/PngToDds/Helpers/DDSFormatHelper.cs
+++ b/Editors/ImportExportEditor/Editors.ImportExport/Importing/Importers/PngToDds/Helpers/DDSFormatHelper.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using DirectXTexNet;
+using Shared.Core.Settings;
+using Shared.GameFormats.RigidModel.Types;
+
+namespace Editors.ImportExport.Importing.Importers.PngToDds.Helpers
+{
+    public class DDSFormatHelper
+    {
+        static private readonly Dictionary<(GameTypeEnum, TextureType), DXGI_FORMAT> _gameTypeAndTextureTypeToFormat = new Dictionary<(GameTypeEnum, TextureType), DXGI_FORMAT>
+        {
+            // spec gloss material games
+            {(GameTypeEnum.Warhammer, TextureType.Diffuse), DXGI_FORMAT.BC1_UNORM_SRGB},
+            {(GameTypeEnum.Warhammer, TextureType.Specular), DXGI_FORMAT.BC1_UNORM_SRGB},
+            {(GameTypeEnum.Warhammer, TextureType.Gloss), DXGI_FORMAT.BC3_UNORM},
+            {(GameTypeEnum.Warhammer, TextureType.Normal), DXGI_FORMAT.BC3_UNORM},
+            {(GameTypeEnum.Warhammer, TextureType.Mask), DXGI_FORMAT.BC3_UNORM},
+
+            {(GameTypeEnum.Warhammer2, TextureType.Diffuse), DXGI_FORMAT.BC1_UNORM_SRGB},
+            {(GameTypeEnum.Warhammer2, TextureType.Specular), DXGI_FORMAT.BC1_UNORM_SRGB},
+            {(GameTypeEnum.Warhammer2, TextureType.Gloss), DXGI_FORMAT.BC3_UNORM},
+            {(GameTypeEnum.Warhammer2, TextureType.Normal), DXGI_FORMAT.BC3_UNORM},
+            {(GameTypeEnum.Warhammer2, TextureType.Mask), DXGI_FORMAT.BC3_UNORM},
+            
+            {(GameTypeEnum.Troy, TextureType.Diffuse), DXGI_FORMAT.BC1_UNORM_SRGB},
+            {(GameTypeEnum.Troy, TextureType.Specular), DXGI_FORMAT.BC1_UNORM_SRGB},
+            {(GameTypeEnum.Troy, TextureType.Gloss), DXGI_FORMAT.BC3_UNORM},
+            {(GameTypeEnum.Troy, TextureType.Normal), DXGI_FORMAT.BC3_UNORM},
+            {(GameTypeEnum.Troy, TextureType.Mask), DXGI_FORMAT.BC3_UNORM},
+
+            {(GameTypeEnum.Pharaoh, TextureType.Diffuse), DXGI_FORMAT.BC1_UNORM_SRGB},
+            {(GameTypeEnum.Pharaoh, TextureType.Specular), DXGI_FORMAT.BC1_UNORM_SRGB},
+            {(GameTypeEnum.Pharaoh, TextureType.Gloss), DXGI_FORMAT.BC3_UNORM},
+            {(GameTypeEnum.Pharaoh, TextureType.Normal), DXGI_FORMAT.BC3_UNORM},
+            {(GameTypeEnum.Pharaoh, TextureType.Mask), DXGI_FORMAT.BC3_UNORM},
+
+            // metal-roughness material games            
+            {(GameTypeEnum.Warhammer3, TextureType.BaseColour), DXGI_FORMAT.BC1_UNORM_SRGB},
+            {(GameTypeEnum.Warhammer3, TextureType.MaterialMap), DXGI_FORMAT.BC1_UNORM_SRGB},
+            {(GameTypeEnum.Warhammer3, TextureType.Normal), DXGI_FORMAT.BC3_UNORM},
+            {(GameTypeEnum.Warhammer3, TextureType.Mask), DXGI_FORMAT.BC3_UNORM},
+
+            // Keys for "Empty" WH3 RMV2, that contains "old" spec-gloss paths pointing nowhere
+            {(GameTypeEnum.Warhammer3, TextureType.Diffuse), DXGI_FORMAT.BC1_UNORM_SRGB},
+            {(GameTypeEnum.Warhammer3, TextureType.Specular), DXGI_FORMAT.BC1_UNORM_SRGB},
+            {(GameTypeEnum.Warhammer3, TextureType.Gloss), DXGI_FORMAT.BC3_UNORM},
+
+            {(GameTypeEnum.ThreeKingdoms, TextureType.BaseColour), DXGI_FORMAT.BC1_UNORM_SRGB},
+            {(GameTypeEnum.ThreeKingdoms, TextureType.MaterialMap), DXGI_FORMAT.BC1_UNORM_SRGB},
+            {(GameTypeEnum.ThreeKingdoms, TextureType.Normal), DXGI_FORMAT.BC3_UNORM},
+            {(GameTypeEnum.ThreeKingdoms, TextureType.Mask), DXGI_FORMAT.BC3_UNORM},            
+            
+            {(GameTypeEnum.RomeRemastered, TextureType.Normal), DXGI_FORMAT.BC3_UNORM},
+            {(GameTypeEnum.Rome2, TextureType.Normal), DXGI_FORMAT.BC3_UNORM},
+            {(GameTypeEnum.Attila, TextureType.Normal), DXGI_FORMAT.BC3_UNORM},            
+            {(GameTypeEnum.Arena, TextureType.Normal), DXGI_FORMAT.BC3_UNORM},
+            
+        };
+
+        public static DXGI_FORMAT GetDDSFormat(GameTypeEnum gameType, TextureType textureType)
+        {
+            if (_gameTypeAndTextureTypeToFormat.TryGetValue((gameType, textureType), out var format))
+                return format;
+
+            // TODO: LOG No format found for gameType and textureType
+
+            return DXGI_FORMAT.BC3_UNORM;                        
+        }
+    }
+}

--- a/Editors/ImportExportEditor/Editors.ImportExport/Importing/Importers/PngToDds/Helpers/ImageProcessor/BlenderToWH3MaterialMapProcessor.cs
+++ b/Editors/ImportExportEditor/Editors.ImportExport/Importing/Importers/PngToDds/Helpers/ImageProcessor/BlenderToWH3MaterialMapProcessor.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
+using DirectXTexNet;
+using Editors.ImportExport.Common.Interfaces;
+
+namespace Editors.ImportExport.Common.Interfaces
+{
+    public class BlenderToWH3MaterialMapProcessor : IImageProcessor
+    {
+        public ScratchImage Transform(ScratchImage scratchImage)
+        {
+            if (!(scratchImage.GetMetadata().Format == DXGI_FORMAT.B8G8R8A8_UNORM || scratchImage.GetMetadata().Format == DXGI_FORMAT.B8G8R8A8_UNORM_SRGB))
+            {
+                throw new Exception($"Error: image format is {scratchImage.GetMetadata().Format}  should be uncompressed RGBA8 (BC_B8G8R8A8_UNORM)");
+            }
+            
+            var copyScratchImage = scratchImage.CreateImageCopy(0, false, CP_FLAGS.NONE);
+            var srcImage = copyScratchImage.GetImage(0, 0, 0);
+            byte[] rgbaBytes = new byte[srcImage.SlicePitch];
+            Marshal.Copy(srcImage.Pixels, rgbaBytes, 0, (int)srcImage.SlicePitch);
+
+            for (int index = 0; index < srcImage.SlicePitch; index += 4)
+            {
+                var r = rgbaBytes[index + 2];
+                var g = rgbaBytes[index + 1];
+                var b = rgbaBytes[index + 0];
+                                
+                rgbaBytes[index + 0] = r;
+                rgbaBytes[index + 1] = g;
+                rgbaBytes[index + 2] = b;
+                rgbaBytes[index + 3] = 255;
+                
+            }
+
+            Marshal.Copy(rgbaBytes, 0, srcImage.Pixels, (int)srcImage.SlicePitch);
+            return copyScratchImage;
+        }
+    }
+}

--- a/Editors/ImportExportEditor/Editors.ImportExport/Importing/Importers/PngToDds/Helpers/ImageProcessor/BlueToOrangeNormalMapImageProcessor.cs
+++ b/Editors/ImportExportEditor/Editors.ImportExport/Importing/Importers/PngToDds/Helpers/ImageProcessor/BlueToOrangeNormalMapImageProcessor.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
+using DirectXTexNet;
+using Editors.ImportExport.Common.Interfaces;
+using Microsoft.Xna.Framework;
+
+namespace Editors.ImportExport.Importing.Importers.PngToDds.Helpers.ImageProcessor
+{
+    public class BlueToOrangeNormalMapProcessor : IImageProcessor
+    {
+        public ScratchImage Transform(ScratchImage scratchImage)
+        {
+            if (!(scratchImage.GetMetadata().Format == DXGI_FORMAT.B8G8R8A8_UNORM || scratchImage.GetMetadata().Format == DXGI_FORMAT.B8G8R8A8_UNORM_SRGB))
+            {
+                throw new Exception($"Error: image format is {scratchImage.GetMetadata().Format}  should be uncompressed RGBA8 (BC_B8G8R8A8_UNORM)");
+            }
+
+            var copyScratchImage = scratchImage.CreateImageCopy(0, false, CP_FLAGS.NONE);
+            var srcImage = copyScratchImage.GetImage(0, 0, 0);
+            byte[] rgbaBytes = new byte[srcImage.SlicePitch];
+
+            // copy data from image pixel pointer to byte array
+            Marshal.Copy(srcImage.Pixels, rgbaBytes, 0, (int)srcImage.SlicePitch);
+
+            for (int index = 0; index < srcImage.SlicePitch; index += 4)
+            {
+                var x_red = rgbaBytes[index + 2];
+                var y_green = rgbaBytes[index + 1];
+
+                rgbaBytes[index + 0] = 0;
+                rgbaBytes[index + 1] = y_green;
+                rgbaBytes[index + 2] = 255;
+                rgbaBytes[index + 3] = x_red;
+
+                rgbaBytes[index + 1] = ColorChannels.GammaComponent(rgbaBytes[index + 1], 1 / 2.2f);
+            }
+
+            // copy processed pixel back to the image pixel pointer½
+            Marshal.Copy(rgbaBytes, 0, srcImage.Pixels, (int)srcImage.SlicePitch);
+            return copyScratchImage;
+        }
+    }
+}

--- a/Editors/ImportExportEditor/Editors.ImportExport/Importing/Importers/PngToDds/Helpers/ImageProcessor/DefaultImageProcessor.cs
+++ b/Editors/ImportExportEditor/Editors.ImportExport/Importing/Importers/PngToDds/Helpers/ImageProcessor/DefaultImageProcessor.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
+using DirectXTexNet;
+using Editors.ImportExport.Common.Interfaces;
+
+namespace Editors.ImportExport.Importing.Importers.PngToDds.Helpers.ImageProcessor
+{
+    public class DefaultImageProcessor : IImageProcessor
+    {
+        public ScratchImage Transform(ScratchImage scratchImage)
+        {          
+            if (!(scratchImage.GetMetadata().Format == DXGI_FORMAT.B8G8R8A8_UNORM || scratchImage.GetMetadata().Format == DXGI_FORMAT.B8G8R8A8_UNORM_SRGB))
+            {
+                throw new Exception($"Error: image format is {scratchImage.GetMetadata().Format}  should be uncompressed RGBA8 (BC_B8G8R8A8_UNORM)");
+            }
+
+            var outScratchImage = scratchImage.CreateImageCopy(0, false, CP_FLAGS.NONE);
+
+            var srcImage = scratchImage.GetImage(0, 0, 0);
+            var destImage = outScratchImage.GetImage(0, 0, 0);
+            
+
+            // copy the pixel pointer's content to a byte array
+            byte[] rgbaBytes = new byte[srcImage.SlicePitch];
+            Marshal.Copy(srcImage.Pixels, rgbaBytes, 0, (int)srcImage.SlicePitch);
+            
+            return outScratchImage;
+        }
+    }
+
+}

--- a/Editors/ImportExportEditor/Editors.ImportExport/Importing/Importers/PngToDds/PngToDdsImporter.cs
+++ b/Editors/ImportExportEditor/Editors.ImportExport/Importing/Importers/PngToDds/PngToDdsImporter.cs
@@ -1,12 +1,36 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using DirectXTexNet;
+using Editors.ImportExport.Importing.Importers.PngToDds.Helpers;
+using Shared.Core.PackFiles.Models;
+using Shared.Core.Settings;
+using Shared.GameFormats.RigidModel.Types;
+using Editors.ImportExport.Common.Interfaces;
 
 namespace Editors.ImportExport.Importing.Importers.PngToDds
 {
-    internal class PngToDdsImporter
+
+    public class PngToDdsImporter
     {
+        static public PackFile Import(string inputPath, TextureType textureType, GameTypeEnum gameType, string outFileName)
+        {
+            ScratchImage scratchImagePng = TexHelper.Instance.LoadFromWICFile(inputPath, WIC_FLAGS.DEFAULT_SRGB);
+
+            bool isUncompressed = scratchImagePng.GetMetadata().Format == DXGI_FORMAT.B8G8R8A8_UNORM || scratchImagePng.GetMetadata().Format == DXGI_FORMAT.B8G8R8A8_UNORM_SRGB;
+
+            var processedImage = ImageProcessorFactory.CreateImageProcessor(textureType).Transform(scratchImagePng);
+            // process image based on texture type
+
+            var imageWithMips = processedImage.GenerateMipMaps(TEX_FILTER_FLAGS.DEFAULT, 0);
+            var ddsFormat = DDSFormatHelper.GetDDSFormat(gameType, textureType);
+            var ddsImage = imageWithMips.Compress(ddsFormat, TEX_COMPRESS_FLAGS.DEFAULT, 0.5f);
+
+            var ddsMemStream = ddsImage.SaveToDDSMemory(DDS_FLAGS.NONE);
+
+            byte[] ddsBytes = new byte[ddsMemStream.Length];
+            ddsMemStream.Read(ddsBytes, 0, ddsBytes.Length);
+
+            var ddsPackFile = new PackFile(outFileName, new MemorySource(ddsBytes));
+
+            return ddsPackFile;
+        }
     }
 }

--- a/Editors/ImportExportEditor/Editors.ImportExport/Importing/Presentation/GltfToRmv/RmvToGltfImporterView.xaml
+++ b/Editors/ImportExportEditor/Editors.ImportExport/Importing/Presentation/GltfToRmv/RmvToGltfImporterView.xaml
@@ -1,0 +1,77 @@
+﻿<UserControl x:Class="Editors.ImportExport.Importing.Presentation.RmvToGltf.RmvToGltfImporterView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:local="clr-namespace:Editors.ImportExport.Importing.Presentation.RmvToGltf"
+             mc:Ignorable="d"                           
+             VerticalAlignment="Stretch"
+                
+             >
+
+    <Grid VerticalAlignment="Stretch">
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="auto"/>
+            <ColumnDefinition Width="auto" MinWidth="9.173"/>
+            <ColumnDefinition Width="auto" MinWidth="322.522"/>
+            <ColumnDefinition Width="auto"/>
+            <ColumnDefinition Width="auto" MinWidth="1"/>
+            <ColumnDefinition/>
+        </Grid.ColumnDefinitions>
+
+        <Grid.RowDefinitions>
+            <RowDefinition Height="25"/>
+            <RowDefinition Height="25"/>
+            <RowDefinition Height="25"/>
+            <RowDefinition Height="25"/>
+            <RowDefinition Height="25"/>
+            <RowDefinition Height="25"/>
+        </Grid.RowDefinitions>
+
+
+        <TextBlock Grid.Row="0" Grid.Column="0" Text="Import Meshes"/>
+        <CheckBox Grid.Column="2" Content="" HorizontalAlignment="Left" VerticalAlignment="Center" x:Name="ImportMeshes_CheckBox"
+                  IsChecked="{Binding ImportMeshes, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}"
+                  ToolTip="Make a TW WH3/3K compatible material from a Blender Material Map"/>
+        <TextBlock Grid.Column="1" Text=" : " VerticalAlignment="Center" Height="15"/>
+
+        <TextBlock Grid.Row="1" Grid.Column="0" HorizontalAlignment="Left" VerticalAlignment="Center" Text="Import Materials" Height="15" Width="88"/>
+        <TextBlock Grid.Row="1" Grid.Column="1" Text=" : " VerticalAlignment="Center" Height="15"/>
+        <CheckBox Grid.Row="1" Grid.Column="2" HorizontalAlignment="Left" x:Name = "ImportMaterialCheckBox"                  
+                  IsChecked="{Binding ImportMaterials, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}" 
+                    ToolTip="Import Materials From RMV File, convert to TW material" >
+        </CheckBox>
+
+        <TextBlock Grid.Row="2" Grid.Column="1" Text="Convert Material Map From Blender To TW format" HorizontalAlignment="Left" VerticalAlignment="Center" Height="15" Width="265" Grid.ColumnSpan="2" Margin="9,0,0,0"/>
+        <TextBlock Grid.Row="2" Grid.Column="3" Text=" : " VerticalAlignment="Center" Height="15" Margin="0,0,1,0"/>
+        <CheckBox Grid.Row="2" Grid.Column="5" HorizontalAlignment="Left" 
+                  IsEnabled="{Binding ImportMaterials, UpdateSourceTrigger=PropertyChanged}" 
+                  IsChecked="{Binding ConvertFromBlenderMaterialMap, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}"
+                  ToolTip="Make a TW WH3/3K compatible material from a Blender Material Map"/>
+
+        <TextBlock Grid.Row="3" Grid.Column="2" Text="Convert Normal Map From Blue To Orange Type" HorizontalAlignment="Left" VerticalAlignment="Center" Height="15" Margin="4,0,0,0" Width="255"/>
+        <TextBlock Grid.Row="3" Grid.Column="3" Text=" : " VerticalAlignment="Top" Height="15" HorizontalAlignment="Center" Width="9"/>
+        <CheckBox Grid.Row="3" Grid.Column="5" HorizontalAlignment="Left" x:Name="ConvertNormalMapCheckbox"
+                  IsEnabled="{Binding ImportMaterials, UpdateSourceTrigger=PropertyChanged}" 
+                  IsChecked="{Binding ConvertNormalTextureToOrange, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}">
+            <CheckBox.ToolTip>
+                Convert the normal map texture from blue type into to orange type. &#xD;&#xA;
+                - Blue type is used by most 3d software, including blender, substance painter. &#xD;&#xA;
+                - Orange type is a specialal "compressed" 2 channel type, used by TW, and some other games.
+            </CheckBox.ToolTip>
+        </CheckBox>
+        <TextBlock Grid.Row="4" Text="Import Animations   " HorizontalAlignment="Center" VerticalAlignment="Center" Height="15" Width="109"/>
+        <TextBlock Grid.Row="4" Grid.Column="1" Text=" : " VerticalAlignment="Center" Height="15"/>
+        <CheckBox Grid.Row="4" Grid.Column="2" HorizontalAlignment="Left" IsChecked="{Binding ImportAnimations, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}">
+            <CheckBox.ToolTip>
+                Import Animations From GLTF File, convert to TW ANIM;
+            </CheckBox.ToolTip>
+        </CheckBox>
+        <TextBlock Grid.Row="5" Grid.Column="2" Text="Number of Key Samples Per Second "  HorizontalAlignment="Left" VerticalAlignment="Center" Height="15" Margin="4,0,0,0" Width="193"/>
+        <TextBlock Grid.Row="5" Grid.Column="3" Text=" : " HorizontalAlignment="Center" VerticalAlignment="Top" Height="16" Width="9" RenderTransformOrigin="8.147,0.333"/>
+        <TextBox Grid.Row="5" Grid.Column="5" HorizontalAlignment="Left" VerticalAlignment="Top" Width="28"
+                 Text="{Binding AnimationKeysPerSecond, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}"/>
+
+    </Grid>
+
+</UserControl>

--- a/Editors/ImportExportEditor/Editors.ImportExport/Importing/Presentation/GltfToRmv/RmvToGltfImporterView.xaml.cs
+++ b/Editors/ImportExportEditor/Editors.ImportExport/Importing/Presentation/GltfToRmv/RmvToGltfImporterView.xaml.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Navigation;
+using System.Windows.Shapes;
+
+namespace Editors.ImportExport.Importing.Presentation.RmvToGltf
+{
+    /// <summary>
+    /// Interaction logic for RmvToGltfExporterView.xaml
+    /// </summary>
+    public partial class RmvToGltfImporterView : UserControl
+    {
+        public RmvToGltfImporterView()
+        {
+            InitializeComponent();
+        }
+
+    }
+}

--- a/Editors/ImportExportEditor/Editors.ImportExport/Importing/Presentation/GltfToRmv/RmvToGltfImporterViewModel.cs
+++ b/Editors/ImportExportEditor/Editors.ImportExport/Importing/Presentation/GltfToRmv/RmvToGltfImporterViewModel.cs
@@ -1,0 +1,55 @@
+﻿using CommunityToolkit.Mvvm.ComponentModel;
+using Editors.ImportExport.Exporting.Exporters.RmvToGltf;
+using Editors.ImportExport.Exporting.Presentation.RmvToGltf;
+using Editors.ImportExport.Importing.Importers;
+using Editors.ImportExport.Importing.Importers.GltfToRmv;
+using Editors.ImportExport.Importing.Presentation;
+using Shared.Core.PackFiles.Models;
+using Shared.Core.Settings;
+using Shared.Ui.Common.DataTemplates;
+using Editors.ImportExport.Importing.Presentation.RmvToGltf;
+using Editors.ImportExport.Misc;
+
+namespace Editors.ImportImport.Importing.Presentation.RmvToGltf
+{
+    public partial class RmvToGltfImporterViewModel : ObservableObject, IImporterViewModel, IViewProvider<RmvToGltfImporterView>
+    {
+        private readonly GltfImporter _Importer;
+
+        public string DisplayName => "Gltf Importer";
+        public string OutputExtension => ".rigid_model_v2";
+        public string[] InputExtensions => new string[] { ".gltf", ".glb" };
+
+        [ObservableProperty] bool _importMeshes = true;        
+        [ObservableProperty] bool _importMaterials = true;
+        [ObservableProperty] bool _convertFromBlenderMaterialMap = true;
+        [ObservableProperty] bool _convertNormalTextureToOrange = true;
+        [ObservableProperty] bool _importAnimations = true;
+        [ObservableProperty] float _animationKeysPerSecond = 20.0f;
+
+        public RmvToGltfImporterViewModel(GltfImporter Importer)
+        {
+            _Importer = Importer;
+        }
+
+        public ImportSupportEnum CanImportFile(PackFile file) => _Importer.CanImportFile(file);
+
+        public void Execute(PackFile importSource, string outputPath, PackFileContainer packFileContainer, GameTypeEnum gameType)
+        {
+            var settings = new GltfImporterSettings(
+                InputGltfFile: importSource.Name,
+                DestinationPackPath: outputPath,
+                DestinationPackFileContainer: packFileContainer,
+                SelectedGame: gameType,
+                ImportMeshes: this.ImportMeshes,
+                ImportMaterials: this.ImportMaterials,
+                ConvertMaterialFromBlenderType: this.ConvertFromBlenderMaterialMap,
+                ConvertNormalTextureFromBlueToOrangeType: this.ConvertNormalTextureToOrange,
+                ImportAnimations: this.ImportAnimations,
+                AnimationKeysPerSecond: this.AnimationKeysPerSecond,
+                MirrorMesh: true);
+
+            _Importer.Import(settings);
+        }
+    }
+}

--- a/Editors/ImportExportEditor/Editors.ImportExport/Importing/Presentation/IImporterViewModel.cs
+++ b/Editors/ImportExportEditor/Editors.ImportExport/Importing/Presentation/IImporterViewModel.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Editors.ImportExport.Misc;
+using Shared.Core.PackFiles.Models;
+using Shared.Core.Settings;
+
+namespace Editors.ImportExport.Importing.Presentation
+{
+    public interface IImporterViewModel
+    {
+        public string DisplayName { get; }
+        string OutputExtension { get; }
+        string[] InputExtensions { get; } // ADDed THIS!
+        public void Execute(PackFile exportSource, string outputPath, PackFileContainer packFileContainer, GameTypeEnum gameType);
+        public ImportSupportEnum CanImportFile(PackFile file);
+
+    }
+}

--- a/Editors/ImportExportEditor/Editors.ImportExport/Importing/Presentation/ImportWindow.xaml
+++ b/Editors/ImportExportEditor/Editors.ImportExport/Importing/Presentation/ImportWindow.xaml
@@ -1,0 +1,59 @@
+﻿<Window x:Class="Editors.ImportExport.Importing.Presentation.ImportWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:local="clr-namespace:Editors.ImportExport.Importing.Presentation"
+        mc:Ignorable="d"
+        Style="{StaticResource CustomWindowStyle}"
+        Title="ImportWindow"  Width="800"                
+         SizeToContent="Height"
+        WindowStartupLocation="CenterScreen"
+        ResizeMode="NoResize">
+
+    <Grid Margin="4">
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="auto"/>
+            <ColumnDefinition Width="auto"/>
+            <ColumnDefinition Width="*"/>
+            <ColumnDefinition Width="auto"/>
+        </Grid.ColumnDefinitions>
+
+        <Grid.RowDefinitions>
+            <RowDefinition Height="25"/>
+            <RowDefinition Height="25"/>
+            <RowDefinition Height="25"/>
+            <RowDefinition Height="auto"/>  
+            <RowDefinition Height="25"/>            
+            <RowDefinition Height="25"/>            
+        </Grid.RowDefinitions>
+
+        <TextBlock Grid.Row="0" Grid.Column="0" Text="Selected File" HorizontalAlignment="Left"/>
+        <TextBlock Grid.Row="0" Grid.Column="1" Text=": "/>
+        <TextBox Grid.Row="0" Grid.Column="2" Text="{Binding SystemPath}" HorizontalContentAlignment="Left" IsReadOnly="True"/>
+        <!--<Button Grid.Row="0" Grid.Column="2" Content="Browse" Command="{Binding BrowsePathCommandCommand}" Grid.ColumnSpan="2" Margin="517,0,0,0"/>-->
+
+        <TextBlock Grid.Row="1" Grid.Column="0" Text="Create Import project   " HorizontalAlignment="Left"/>
+        <TextBlock Grid.Row="1" Grid.Column="1" Text=": "/>
+        <CheckBox Grid.Row="1" Grid.Column="2" HorizontalAlignment="Left" IsChecked="{Binding CreateImportProject, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}"/>
+
+        <TextBlock Grid.Row="2" Grid.Column="0" HorizontalAlignment="Left" Text="Available Importers"/>
+        <TextBlock Grid.Row="2" Grid.Column="1" Text=": "/>
+        <ComboBox Grid.Row="2" Grid.Column="2"  HorizontalContentAlignment="Left"
+            ItemsSource="{Binding PossibleImporters, UpdateSourceTrigger=PropertyChanged}"
+            SelectedValue="{Binding SelectedImporter, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}" 
+            DisplayMemberPath = "DisplayName"/>
+
+        <Expander Grid.Row="3" Grid.Column="1" Grid.ColumnSpan="3" Header="Importer Settings:" IsExpanded="True"  HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
+            <Border BorderBrush="Gray" BorderThickness="2" Margin="2">
+                <ContentControl BorderThickness="2"
+                          Content="{Binding SelectedImporter, UpdateSourceTrigger=PropertyChanged}"       
+                          ContentTemplateSelector="{StaticResource ViewTemplateDataSelector}"/>
+            </Border>
+        </Expander>
+
+        <Button Grid.Row="5" Grid.ColumnSpan="4" Content="Import" Click="ImportButton_Click"/>
+
+
+    </Grid>
+</Window>

--- a/Editors/ImportExportEditor/Editors.ImportExport/Importing/Presentation/ImportWindow.xaml.cs
+++ b/Editors/ImportExportEditor/Editors.ImportExport/Importing/Presentation/ImportWindow.xaml.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Shapes;
+using Editors.ImportExport.Exporting.Presentation;
+using Editors.ImportExport.Importing.Presentation;
+using Editors.ImportExport.Misc;
+using Shared.Core.PackFiles.Models;
+
+namespace Editors.ImportExport.Importing.Presentation
+{
+    public partial class ImportWindow : Window
+    {
+        private readonly ImporterCoreViewModel _viewModel;
+
+        public ImportWindow(ImporterCoreViewModel viewModel)
+        {
+            InitializeComponent();
+            _viewModel = viewModel;
+            DataContext = _viewModel;
+        }
+
+        internal void Initialize(PackFileContainer packFileContainer, string packPath, string diskFile)
+        {
+            _viewModel.Initialize(packFileContainer, packPath, diskFile);            
+        }
+
+        private void ImportButton_Click(object sender, RoutedEventArgs e)
+        {
+            if (!PathValidator.IsValid(_viewModel.SystemPath))
+            {
+                MessageBox.Show("Invalid or empty path", "Error");
+                return;
+            }
+
+            _viewModel.Import();
+            Close();
+        }       
+    }
+}

--- a/Editors/ImportExportEditor/Editors.ImportExport/Importing/Presentation/ImporterCoreViewModel.cs
+++ b/Editors/ImportExportEditor/Editors.ImportExport/Importing/Presentation/ImporterCoreViewModel.cs
@@ -1,0 +1,86 @@
+﻿using System.Collections.ObjectModel;
+using System.IO;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Editors.ImportExport.Misc;
+using Shared.Core.PackFiles.Models;
+using Shared.Core.Settings;
+
+namespace Editors.ImportExport.Importing.Presentation
+{
+    // Importer
+    // --------------------------
+    //  Checkbox | Type | Path | Last changed | Need refresh    | Remove Button |
+    // --------------------------
+    //  Checkbox | Type | Path | Last changed | Need refresh    | Remove Button |
+    // --------------------------
+    // | Update all Button |
+    // => SHow status window after done with OK | Errors
+
+
+    public partial class ImporterCoreViewModel : ObservableObject
+    {
+        private readonly ApplicationSettingsService _applicationSettings;
+
+        private readonly IEnumerable<IImporterViewModel> _exporterViewModels;
+        PackFile? _inputFile;
+        PackFileContainer? _destPackFileContainer;
+        string _packPath = "";
+
+        [ObservableProperty] IImporterViewModel? _selectedImporterViewModel;
+        [ObservableProperty] ObservableCollection<IImporterViewModel> _possibleImporters = [];
+        [ObservableProperty] IImporterViewModel? _selectedImporter;
+        [ObservableProperty] string _systemPath = "";
+        [ObservableProperty] bool _createImportProject = true;
+
+        public ImporterCoreViewModel(IEnumerable<IImporterViewModel> exporterViewModels, ApplicationSettingsService applicationSettings)
+        {
+            _exporterViewModels = exporterViewModels;
+            _applicationSettings = applicationSettings;
+        }
+
+        public void Initialize(PackFileContainer packFile, string packPath, string diskFile)
+        {
+            _destPackFileContainer = packFile;
+            _packPath = packPath;
+            SystemPath = diskFile;
+
+
+
+            _inputFile = new PackFile(SystemPath, new FileSystemSource(SystemPath));
+            FindImporter();
+        }
+
+        public void FindImporter()        
+        {            
+            
+
+            if(_inputFile == null)
+                throw new ArgumentNullException(nameof(_inputFile), "Fatal Eroor, cannot be null");
+
+            foreach (var viewModel in _exporterViewModels)
+            {
+                var supported = viewModel.CanImportFile(_inputFile);
+                if (supported == ImportSupportEnum.NotSupported)
+                    continue;
+
+                PossibleImporters.Add(viewModel);                
+
+                if (supported == ImportSupportEnum.HighPriority)
+                    SelectedImporter = viewModel;
+            }
+
+            if (SelectedImporter == null)
+                SelectedImporter = PossibleImporters.First();
+        }
+
+        public void Import() => SelectedImporter!.Execute(_inputFile, _packPath, _destPackFileContainer, _applicationSettings.CurrentSettings.CurrentGame);
+
+        [RelayCommand]
+        public void BrowsePathCommand()
+        {
+            int i = 10;
+            i = i + 10;
+        }
+    }
+}

--- a/Editors/ImportExportEditor/Editors.ImportExport/Misc/FileExtensionHelper.cs
+++ b/Editors/ImportExportEditor/Editors.ImportExport/Misc/FileExtensionHelper.cs
@@ -3,28 +3,33 @@ namespace Editors.ImportExport.Misc
 {
     public static class FileExtensionHelper
     {
+        public static bool IsGltfFile(string fileName)
+        {            
+            return fileName.EndsWith(".gltf", StringComparison.InvariantCultureIgnoreCase);
+        }
+
         public static bool IsDdsFile(string fileName)
         {
-            var isDdsFile = fileName.Contains(".dds", StringComparison.InvariantCultureIgnoreCase);
+            var isDdsFile = fileName.EndsWith(".dds", StringComparison.InvariantCultureIgnoreCase);
             return isDdsFile;
         }
 
         public static bool IsDdsMaterialFile(string fileName)
         {
             var isDdsFile = IsDdsFile(fileName);
-            var isMaterialFile = fileName.Contains("material", StringComparison.InvariantCultureIgnoreCase);
+            var isMaterialFile = fileName.EndsWith("material", StringComparison.InvariantCultureIgnoreCase);
             return isDdsFile && isMaterialFile;
         }
 
         public static bool IsRmvFile(string fileName)
         {
-            var isRmv = fileName.Contains(".rigid_model_v2", StringComparison.InvariantCultureIgnoreCase);
+            var isRmv = fileName.EndsWith(".rigid_model_v2", StringComparison.InvariantCultureIgnoreCase);
             return isRmv;
         }
 
         public static bool IsWsModelFile(string fileName)
         {
-            var isRmv = fileName.Contains(".wsmodel", StringComparison.InvariantCultureIgnoreCase);
+            var isRmv = fileName.EndsWith(".wsmodel", StringComparison.InvariantCultureIgnoreCase);
             return isRmv;
         }
     }

--- a/Editors/ImportExportEditor/Editors.ImportExport/Misc/ImportSupportEnum.cs
+++ b/Editors/ImportExportEditor/Editors.ImportExport/Misc/ImportSupportEnum.cs
@@ -1,0 +1,9 @@
+﻿namespace Editors.ImportExport.Misc
+{
+    public enum ImportSupportEnum
+    {
+        Supported,
+        NotSupported,
+        HighPriority
+    }
+}

--- a/Editors/ImportExportEditor/Test.ImportExport/Exporting/Exporters/RmvToGlft/RmvToGltfExporterTests.cs
+++ b/Editors/ImportExportEditor/Test.ImportExport/Exporting/Exporters/RmvToGlft/RmvToGltfExporterTests.cs
@@ -34,7 +34,7 @@ namespace Test.ImportExport.Exporting.Exporters.RmvToGlft
             // Act
             var mesh = pfs.FindFile(_rmvFilePathKarl);
             var exporter = new RmvToGltfExporter(sceneSaver, meshBuilder, textureHandler, skeletontonBuilder, animationBuilder, skeletontonLookupHelper);
-            var settings = new RmvToGltfExporterSettings(mesh!, [], @"C:\test\myExport.gltf", true, true, true, true);
+            var settings = new RmvToGltfExporterSettings(mesh!, [], @"C:\test\myExport.gltf", true, true, true, true, true);
             exporter.Export(settings);
 
             // Assert

--- a/Editors/ImportExportEditor/Test.ImportExport/Importing/Importers/GltfToRmvImporter/GltfIToRmvImporterTests.cs
+++ b/Editors/ImportExportEditor/Test.ImportExport/Importing/Importers/GltfToRmvImporter/GltfIToRmvImporterTests.cs
@@ -33,17 +33,18 @@ namespace Test.ImportExport.Importing.Importers.GltfImporterTest
 
         public static class Rmv2Expected
         {
-            public const string skeletonName = "humanoid01";
+            public const string skeletonName = "humanoid01";            
             public const int lodCount = 1;
             public const int lod0MeshCount = 4;
             public const int Lod0Mesh0IndexCount = 25539;
             public const int Lod0Mesh0VertexCount = 6397;
+            public const int Lod0Mesh0TextureCount = 3;
         }
     }
 
     // Tests Full Import (Importer.Import())
     class GltfToRmv2ImporterTest
-    {     
+    {
         [Test]
         public void Test()
         {
@@ -51,56 +52,59 @@ namespace Test.ImportExport.Importing.Importers.GltfImporterTest
             var pfs = PackFileSerivceTestHelper.Create(TestData.InputPack);
 
             var meshBuilder = new GltfMeshBuilder();
-            var normalExporter = new Mock<IDdsToNormalPngExporter>();
-            var materialExporter = new Mock<IDdsToMaterialPngExporter>();
             var eventHub = new Mock<IGlobalEventHub>();
             var skeletontonLookupHelper = new SkeletonAnimationLookUpHelper(pfs, eventHub.Object);
             var skeletontonBuilder = new GltfSkeletonBuilder(pfs);
             var animationBuilder = new GltfAnimationBuilder(pfs);
-            var textureHandler = new GltfTextureHandler(normalExporter.Object, materialExporter.Object);
             var sceneSaver = new TestGltfSceneSaver();
             var standardDialog = new Mock<IStandardDialogs>();
-            var sceneLoader = new GltfSceneLoader(standardDialog.Object);            
-            var importer = new GltfImporter(pfs, standardDialog.Object, skeletontonLookupHelper);
-
+            var sceneLoader = new GltfSceneLoader(standardDialog.Object);
+            var materialBuilder = new RmvMaterialBuilder(pfs, standardDialog.Object);
+            var importer = new GltfImporter(pfs, standardDialog.Object, skeletontonLookupHelper, materialBuilder);
             var packFileContainer = new PackFileContainer("new");
-            var settings = new GltfImporterSettings(TestData.InputGtlfFile, "skeletons", packFileContainer, true, true, true);
+            var settings = new GltfImporterSettings(TestData.InputGtlfFile, "skeletons", packFileContainer, Shared.Core.Settings.GameTypeEnum.Warhammer3, true, true, true, true, true, 20.0f, true);
 
             // Act
-            // Do full import
             importer.Import(settings);
-            var rmv2FileName = @$"skeletons\{Path.GetFileNameWithoutExtension(TestData.InputGtlfFile)}.rigid_model_v2".ToLower();
-            var isPackFileAdded = packFileContainer.FileList.ContainsKey(rmv2FileName);
-
-            // Assert
-            // Last step of Importer, is adding the file to PackFileContainer, so we check wether this has happened
-            Assert.That(isPackFileAdded, Is.EqualTo(true));
+            var rmv2FileName = @$"{settings.DestinationPackPath}\{Path.GetFileNameWithoutExtension(settings.InputGltfFile)}.rigid_model_v2".ToLower();
+            var isPackFileAddedToContainer = packFileContainer.FileList.TryGetValue(rmv2FileName, out var packFile);
+                         
+            //  Assert                        
+            Assert.That(isPackFileAddedToContainer, Is.EqualTo(true));            
+            var rmv2File = ModelFactory.Create().Load(packFile!.DataSource!.ReadData());
+            Assert.That(rmv2File, Is.Not.Null);
+            Assert.That(rmv2File!.LodHeaders.Length, Is.EqualTo(TestData.Rmv2Expected.lodCount));            
+            Assert.That(rmv2File!.LodHeaders[0].MeshCount, Is.EqualTo(TestData.Rmv2Expected.lod0MeshCount));
+            
+            Assert.That(rmv2File!.ModelList.Length, Is.EqualTo(TestData.Rmv2Expected.lodCount));
+            Assert.That(rmv2File!.ModelList[0].Length, Is.EqualTo(TestData.Rmv2Expected.lod0MeshCount));
+            
+            Assert.That(rmv2File!.ModelList[0][0]!.Material!.GetAllTextures().Count(), Is.EqualTo(TestData.Rmv2Expected.Lod0Mesh0TextureCount));
+            Assert.That(rmv2File!.ModelList[0][0]!.Mesh.IndexList.Length, Is.EqualTo(TestData.Rmv2Expected.Lod0Mesh0IndexCount));
+            Assert.That(rmv2File!.ModelList[0][0]!.Mesh.VertexList.Length, Is.EqualTo(TestData.Rmv2Expected.Lod0Mesh0VertexCount));
         }
     }
 
     // Tests some Components of Importer pipeline
     class GltfToRmv2ImporterComponentTest
-    {       
-
+    {
         [Test]
-        public void Test()
+        public void TestGltfApiLoad()
         {
             // Arrange 
             var pfs = PackFileSerivceTestHelper.Create(TestData.InputPack);
 
             var meshBuilder = new GltfMeshBuilder();
-            var normalExporter = new Mock<IDdsToNormalPngExporter>();
-            var materialExporter = new Mock<IDdsToMaterialPngExporter>();
             var eventHub = new Mock<IGlobalEventHub>();
             var standardDialog = new Mock<IStandardDialogs>();
             var skeletontonLookupHelper = new SkeletonAnimationLookUpHelper(pfs, eventHub.Object);
             var skeletontonBuilder = new GltfSkeletonBuilder(pfs);
             var animationBuilder = new GltfAnimationBuilder(pfs);
-            var textureHandler = new GltfTextureHandler(normalExporter.Object, materialExporter.Object);
+            var materialBuilder = new RmvMaterialBuilder(pfs, standardDialog.Object);
             var sceneLoader = new GltfSceneLoader(standardDialog.Object);
             var skeletonFile = skeletontonLookupHelper.GetSkeletonFileFromName(TestData.Rmv2Expected.skeletonName);
             var packFileContainer = new PackFileContainer("new");
-            var settings = new GltfImporterSettings(TestData.InputGtlfFile, "skeletons", packFileContainer, true, true, true);
+            var settings = new GltfImporterSettings(TestData.InputGtlfFile, "skeletons", packFileContainer, Shared.Core.Settings.GameTypeEnum.Warhammer3, true, true, true, true, true, 20.0f, true);
 
             // Act....          
             var modelRoot = sceneLoader.Load(settings);
@@ -116,11 +120,32 @@ namespace Test.ImportExport.Importing.Importers.GltfImporterTest
             Assert.That(modelRoot.LogicalMeshes[0].Primitives!.Count(), Is.EqualTo(TestData.GltfExpected.primtivesMesh0));
             Assert.That(modelRoot.LogicalMeshes[0].Primitives[0].GetIndices().Count(), Is.EqualTo(TestData.GltfExpected.primtivesMesh0IndexCount));
 
-            // Assert
-            // Test Importer code, check if Rmv2 file is created correctly
-           
+        }
+
+        [Test]
+        public void TestRmvMesgBuilder()
+        {
+            //  Arrange *
+            var pfs = PackFileSerivceTestHelper.Create(TestData.InputPack);
+
+            var meshBuilder = new GltfMeshBuilder();
+            var eventHub = new Mock<IGlobalEventHub>();
+            var standardDialog = new Mock<IStandardDialogs>();
+            var skeletontonLookupHelper = new SkeletonAnimationLookUpHelper(pfs, eventHub.Object);
+            var skeletontonBuilder = new GltfSkeletonBuilder(pfs);
+            var animationBuilder = new GltfAnimationBuilder(pfs);
+            var materialBuilder = new RmvMaterialBuilder(pfs, standardDialog.Object);
+            var sceneLoader = new GltfSceneLoader(standardDialog.Object);
+            var skeletonFile = skeletontonLookupHelper.GetSkeletonFileFromName(TestData.Rmv2Expected.skeletonName);
+            var packFileContainer = new PackFileContainer("new");
+            var settings = new GltfImporterSettings(TestData.InputGtlfFile, "skeletons", packFileContainer, Shared.Core.Settings.GameTypeEnum.Warhammer3, true, true, true, true, true, 20.0f, true);
+
+            //  Act 
+            var modelRoot = sceneLoader.Load(settings);
+            var rmv2Mesh = RmvMeshBuilder.Build(settings, modelRoot, skeletonFile, TestData.Rmv2Expected.skeletonName.ToLower());
+
+            // Assert             
             Assert.That(skeletonFile, Is.Not.Null);
-            var rmv2Mesh = RmvMeshBuilder.Build(settings, modelRoot, skeletonFile, TestData.Rmv2Expected.skeletonName);            
             Assert.That(rmv2Mesh, Is.Not.Null);
             Assert.That(rmv2Mesh.Header.SkeletonName, Is.EqualTo(TestData.Rmv2Expected.skeletonName));
             Assert.That(rmv2Mesh.ModelList, Is.Not.Null);

--- a/Shared/SharedUI/BaseDialogs/PackFileTree/ContextMenu/External/IImportFileContextMenuHelper.cs
+++ b/Shared/SharedUI/BaseDialogs/PackFileTree/ContextMenu/External/IImportFileContextMenuHelper.cs
@@ -1,4 +1,6 @@
-﻿namespace Shared.Ui.BaseDialogs.PackFileTree.ContextMenu.External
+﻿using Shared.Core.PackFiles.Models;
+
+namespace Shared.Ui.BaseDialogs.PackFileTree.ContextMenu.External
 {
     public interface IImportFileContextMenuHelper
     {
@@ -7,7 +9,7 @@
         /// </summary>
         /// <param name="filePath"></param>
         /// <returns></returns>
-        bool CanImportFile(string filePath);
+        bool CanImportFile(PackFile file);
 
         // implemenation returns packfile container, so it can create new foldders
         public void ShowDialog(TreeNode node);

--- a/Shared/SharedUI/BaseDialogs/PackFileTree/ContextMenu/MainApplicationContextMenuBuilder.cs
+++ b/Shared/SharedUI/BaseDialogs/PackFileTree/ContextMenu/MainApplicationContextMenuBuilder.cs
@@ -87,7 +87,9 @@ namespace Shared.Ui.BaseDialogs.PackFileTree.ContextMenu
                 var importFolder = AddChildMenu("Import", rootNode);
                 Add<ImportFileCommand>(selectedNode, importFolder);
                 Add<ImportDirectoryCommand>(selectedNode, importFolder);
-                Add<AdvancedImportCommand>(selectedNode, importFolder);
+
+                if (selectedNode.NodeType != NodeType.Root)
+                    Add<AdvancedImportCommand>(selectedNode, importFolder);
 
                 var createMenu = AddChildMenu("Create", rootNode);
                 Add<CreateFolderCommand>(selectedNode, createMenu);


### PR DESCRIPTION
### Update and fix to GLTF **import**

Importing of GLTF files was not functioal and/or it lacked maany features

I have essentially copied the system Ole made for GLTF EXPORT, and used it for IMPORT, incluidig UI = an import dialog box. 
The import dialog is a different style, and I intend to change the export dialog to follow this style, too

### This is the functionality that is added/fixed:

<details>
<summary>Images and description of addistions </summary>

###  User selects file and picks menu item from context menu:
**"Advanced Import"**
Fixed: Issue where you could use "avance import" on the pack root node
<img width="822" height="462" alt="image" src="https://github.com/user-attachments/assets/87b90aa9-bd3e-4e7b-b78b-0e1abefb2fd4" />

### AE Shows:
User is presented with **"Open File"**, user select a file to import
<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/251ed9cc-b31d-4a8e-aa3e-ca977c3a68b0" />

### AE Shows newly designed **import dialog**
<img width="1280" height="719" alt="image" src="https://github.com/user-attachments/assets/932d605c-af31-4f65-b6b3-eb5923304408" />

### AE imports, converts to **RMV2**, user opens result in viewer.
<img width="1280" height="719" alt="image" src="https://github.com/user-attachments/assets/eeaf73bf-8ecf-4991-a094-7f1412797d54" />

</details>

### Notes
- If one export/imports witthout changing settings it should work flawlessly. But there might be compinations of settings that
  does not work properly
- are logically non-sensiccal / illegal, but the user is not prevent from clicking "import"
- almost all changes should be inside the ImportExport branch, aside from the bug-fix for the root note node  import menu fix
- More Unit Tests should be added
- Some real-world testing would be good

