### PR TITLE
Corruption fixes maybe?

### DIFF
--- a/Shared/SharedCore/PackFiles/PackFileService.cs
+++ b/Shared/SharedCore/PackFiles/PackFileService.cs
@@ -273,8 +273,7 @@ namespace Shared.Core.PackFiles
                     throw new Exception("File has been changed outside of AssetEditor. Can not save the file as it will cause corruptions");
             }
 
-            pf.SystemFilePath = path;
-            using (var memoryStream = new FileStream(path + "_temp", FileMode.OpenOrCreate))
+            using (var memoryStream = new FileStream(path + "_temp", FileMode.Create))
             {
                 using var writer = new BinaryWriter(memoryStream);
                 pf.SaveToByteArray(writer, gameInformation);
@@ -283,6 +282,7 @@ namespace Shared.Core.PackFiles
             File.Delete(path);
             File.Move(path + "_temp", path);
 
+            pf.SystemFilePath = path;
             pf.OriginalLoadByteSize = new FileInfo(path).Length;
 
             _globalEventHub?.PublishGlobalEvent(new PackFileContainerSavedEvent(pf));

--- a/Shared/SharedUI/BaseDialogs/PackFileTree/ContextMenu/Commands/ExportToDirectoryCommand.cs
+++ b/Shared/SharedUI/BaseDialogs/PackFileTree/ContextMenu/Commands/ExportToDirectoryCommand.cs
@@ -9,14 +9,15 @@ namespace Shared.Ui.BaseDialogs.PackFileTree.ContextMenu.Commands
         public string GetDisplayName(TreeNode node) => "Export to system folder";
         public bool IsEnabled(TreeNode node) => true;
 
-        public void Execute(TreeNode _selectedNode)
+        public void Execute(TreeNode selectedNode)
         {
+            // TODO: Fix bug where if you export the packfilecontainer itself it doesn't export correctly.
             var dialog = new FolderBrowserDialog();
             if (dialog.ShowDialog() == DialogResult.OK)
             {
-                var nodeStartDir = Path.GetDirectoryName(_selectedNode.GetFullPath());
+                var nodeStartDir = Path.GetDirectoryName(selectedNode.GetFullPath());
                 var fileCounter = 0;
-                SaveSelfAndChildren(_selectedNode, dialog.SelectedPath, nodeStartDir, ref fileCounter);
+                SaveSelfAndChildren(selectedNode, dialog.SelectedPath, nodeStartDir, ref fileCounter);
                 MessageBox.Show($"{fileCounter} files exported!");
             }
         }
@@ -33,7 +34,7 @@ namespace Shared.Ui.BaseDialogs.PackFileTree.ContextMenu.Commands
                 var nodeOriginalPath = node.GetFullPath();
 
                 var nodePathWithoutRoot = nodeOriginalPath;
-                if (rootPath.Length != 0)
+                if (rootPath != null && rootPath.Length != 0)
                     nodePathWithoutRoot = nodeOriginalPath.Replace(rootPath, "");
 
                 if (nodePathWithoutRoot.StartsWith("\\") == false)
@@ -56,7 +57,3 @@ namespace Shared.Ui.BaseDialogs.PackFileTree.ContextMenu.Commands
     }
 
 }
-
-/*
-
- */


### PR DESCRIPTION
- Fixed a potential filename length calculation issue due to some special characters by using UTF-8 byte count instead of character count.
- Fixed potential issue with temp files by using FileMode.Create instead to prevent reusing incorrect data.
- Moved SystemFilePath to after file move to prevent reads from a potentially wrong file.
- Added assertion against saving with encryption as we don't support that.