### PR TITLE
Make directional light follow camera rotation

### DIFF
--- a/GameWorld/View3D/Components/Rendering/CommonShaderParameterBuilder.cs
+++ b/GameWorld/View3D/Components/Rendering/CommonShaderParameterBuilder.cs
@@ -7,15 +7,20 @@ namespace GameWorld.Core.Components.Rendering
     {
         public static CommonShaderParameters Build(ArcBallCamera camera, SceneRenderParametersStore sceneLightParameters)
         {
+            // Light follows camera rotation for better model visibility
+            float dirLightRotX = MathHelper.ToRadians(sceneLightParameters.DirLightRotationDegrees_X) + camera.Pitch;
+            float dirLightRotY = MathHelper.ToRadians(sceneLightParameters.DirLightRotationDegrees_Y) + camera.Yaw;
+            float envLightRotY = MathHelper.ToRadians(sceneLightParameters.EnvLightRotationDegrees_Y) + camera.Yaw;
+
             var commonShaderParameters = new CommonShaderParameters(
                 camera.ViewMatrix,
                 camera.ProjectionMatrix,
                 camera.Position,
                 camera.LookAt,
 
-                MathHelper.ToRadians(sceneLightParameters.EnvLightRotationDegrees_Y),
-                MathHelper.ToRadians(sceneLightParameters.DirLightRotationDegrees_X),
-                MathHelper.ToRadians(sceneLightParameters.DirLightRotationDegrees_Y),
+                envLightRotY,
+                dirLightRotX,
+                dirLightRotY,
                 sceneLightParameters.LightIntensityMult,
 
                 [sceneLightParameters.FactionColour0, sceneLightParameters.FactionColour1, sceneLightParameters.FactionColour2],


### PR DESCRIPTION
Adds camera Yaw/Pitch to the directional light rotation angles, so the light source moves with the camera viewport. This improves model visibility when viewing from different angles, as the lit side of the model remains visible regardless of camera position.