### PR TITLE
Fix language switching, localization gaps, and auto-detect system language

### DIFF
--- a/AssetEditor/App.xaml.cs
+++ b/AssetEditor/App.xaml.cs
@@ -1,4 +1,6 @@
 ﻿using System.Diagnostics;
+using System.Globalization;
+using System.IO;
 using System.Windows;
 using System.Windows.Threading;
 using AssetEditor.Services;
@@ -56,9 +58,18 @@ namespace AssetEditor
             settingsService.AllowSettingsUpdate = true;
             settingsService.Load();
 
+            // Auto-detect system language for first-time users
+            if (settingsService.CurrentSettings.IsFirstTimeStartingApplication)
+            {
+                var detectedLang = DetectSystemLanguage();
+                if (File.Exists($"Language_{detectedLang}.json"))
+                    settingsService.CurrentSettings.SelectedLangauge = detectedLang;
+                settingsService.Save();
+            }
+
             var localizationManager = _serviceProvider.GetRequiredService<LocalizationManager>();
             localizationManager.GetPossibleLanguages();
-            localizationManager.LoadLanguage("en");
+            localizationManager.LoadLanguage(settingsService.CurrentSettings.SelectedLangauge);
 
             // Show the settings window if its the first time the tool is ran
             if (settingsService.CurrentSettings.IsFirstTimeStartingApplication)
@@ -91,6 +102,18 @@ namespace AssetEditor
 
             settingsService.CurrentSettings.IsFirstTimeStartingApplication = false;
             settingsService.Save();
+        }
+
+        private static string DetectSystemLanguage()
+        {
+            var twoLetter = CultureInfo.CurrentUICulture.TwoLetterISOLanguageName;
+            return twoLetter switch
+            {
+                "zh" => "cn",
+                "en" => "en",
+                "fr" => "fr",
+                _ => "en"
+            };
         }
 
         private void LoadCAPackFiles(ApplicationSettingsService settingsService)

--- a/AssetEditor/Language_Cn.json
+++ b/AssetEditor/Language_Cn.json
@@ -106,7 +106,9 @@
   "MenuBar.File.NewAnimPackWh3": "新建 AnimPack (战锤 III)",
   "MenuBar.File.NewAnimPack3K": "新建 AnimPack (三国)",
   "MenuBar.File.SaveActivePack": "保存当前 Pack",
-  "MenuBar.File.OpenPack": "打开 Pack",
+  "MenuBar.File.OpenProjectFolder": "打开项目",
+  "MenuBar.File.ImportPackAsProject": "将 Pack 导入为项目",
+  "MenuBar.File.ImportReferencePack": "导入参考项目",
   "MenuBar.File.OpenRecentPacks": "打开最近的 Pack",
   "MenuBar.File.OpenGamePacks": "打开游戏 Pack",
   "MenuBar.File.GameAttila": "阿提拉",
@@ -124,7 +126,7 @@
   "MenuBar.Tools": "工具",
   "MenuBar.Reports": "报告",
   "MenuBar.Reports.Rmv2": "Rmv2",
-  "MenuBar.Reports.RmvToText": "Rmv to Text",
+  "MenuBar.Reports.Bmd": "Bmd 地图报告",
   "MenuBar.Reports.MetaData": "元数据",
   "MenuBar.Reports.FileList": "文件列表",
   "MenuBar.Reports.MetaJsons": "元 Json",
@@ -568,6 +570,7 @@
   "FbxAnimationPanel.Browse": "浏览...",
 
   "Dialog.Filter.Browse": "浏览",
+  "Dialog.Filter.Hide": "隐藏",
 
   "KitbashTool.SaveDialog.Title": "保存",
   "KitbashTool.SaveDialog.Path": "路径:",
@@ -883,11 +886,11 @@
   "FbxSettingsDialog.Import": "导入",
   "FbxSettingsDialog.Cancel": "取消",
 
-  "PackFileCache.InvalidReason.Title": "Cache Rebuild Required",
-  "PackFileCache.InvalidReason.NotFound": "No cache found for {0}. Building cache for the first time - this may take a moment.",
-  "PackFileCache.InvalidReason.DataChanged": "Game files for {0} have changed since the cache was built. Rebuilding cache.",
-  "PackFileCache.InvalidReason.Corrupted": "Cache for {0} is corrupted and will be rebuilt.",
-  "PackFileCache.BuildingCache": "Building pack file cache for {0}. This may take some time, please wait...",
-  "PackFileCache.BuildingCache.Title": "Building Cache",
-  "PackFileCache.Description": "The cache allows faster startup times and reduces memory usage by storing pre-processed game file data on disk."
+  "PackFileCache.InvalidReason.Title": "需要重建缓存",
+  "PackFileCache.InvalidReason.NotFound": "未找到 {0} 的缓存。首次构建缓存 - 这可能需要一些时间。",
+  "PackFileCache.InvalidReason.DataChanged": "{0} 的游戏文件自缓存构建后已更改。正在重建缓存。",
+  "PackFileCache.InvalidReason.Corrupted": "{0} 的缓存已损坏，将被重建。",
+  "PackFileCache.BuildingCache": "正在为 {0} 构建 Pack 文件缓存。这可能需要一些时间，请稍候...",
+  "PackFileCache.BuildingCache.Title": "正在构建缓存",
+  "PackFileCache.Description": "缓存通过将预处理的游戏文件数据存储在磁盘上来加快启动速度并减少内存使用。"
 }

--- a/AssetEditor/Language_En.json
+++ b/AssetEditor/Language_En.json
@@ -126,7 +126,7 @@
   "MenuBar.Tools": "Tools",
   "MenuBar.Reports": "Reports",
   "MenuBar.Reports.Rmv2": "Rmv2",
-  "MenuBar.Reports.RmvToText": "Rmv to Text",
+  "MenuBar.Reports.Bmd": "Bmd Report",
   "MenuBar.Reports.MetaData": "Meta Data",
   "MenuBar.Reports.FileList": "File List",
   "MenuBar.Reports.MetaJsons": "Meta Jsons",
@@ -570,6 +570,7 @@
   "FbxAnimationPanel.Browse": "Browse...",
 
   "Dialog.Filter.Browse": "Browse",
+  "Dialog.Filter.Hide": "Hide",
 
   "KitbashTool.SaveDialog.Title": "Save",
   "KitbashTool.SaveDialog.Path": "Path:",

--- a/Shared/SharedUI/Shared.Ui/BaseDialogs/FilterDialog/CollapsableFilterControl.xaml.cs
+++ b/Shared/SharedUI/Shared.Ui/BaseDialogs/FilterDialog/CollapsableFilterControl.xaml.cs
@@ -2,9 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections;
 using System.Windows;
 using System.Windows.Controls;
+using Microsoft.Extensions.DependencyInjection;
+using Shared.Core.Services;
+using Shared.Ui.Common;
 using static CommonControls.FilterDialog.FilterUserControl;
 
 namespace CommonControls.FilterDialog
@@ -22,13 +26,14 @@ namespace CommonControls.FilterDialog
             BrowseButton.Click += (a, b) => ToggleSearchFiled();
             ClearButton.Click += (a, b) => ClearSelection();
             FilterBox.Visibility = Visibility.Collapsed;
+            BrowseButton.Content = GetLocalizedString("Dialog.Filter.Browse");
         }
 
         void HandleItemDoubleClicked()
         {
             HandleOnItemSelected();
             FilterBox.Visibility = Visibility.Collapsed;
-            BrowseButton.Content = "Browse";
+            BrowseButton.Content = GetLocalizedString("Dialog.Filter.Browse");
         }
 
         void HandleOnItemSelected()
@@ -64,13 +69,23 @@ namespace CommonControls.FilterDialog
             if (FilterBox.Visibility == Visibility.Visible)
             {
                 FilterBox.Visibility = Visibility.Collapsed;
-                BrowseButton.Content = "Browse";
+                BrowseButton.Content = GetLocalizedString("Dialog.Filter.Browse");
             }
             else
             {
-                BrowseButton.Content = "Hide";
+                BrowseButton.Content = GetLocalizedString("Dialog.Filter.Hide");
                 FilterBox.Visibility = Visibility.Visible;
             }
+        }
+
+        private static string GetLocalizedString(string key)
+        {
+            if (Application.Current is IAssetEditorMain appMain)
+            {
+                var localizationManager = appMain.ServiceProvider.GetRequiredService<LocalizationManager>();
+                return localizationManager.Get(key);
+            }
+            return key;
         }
         #region properties
 


### PR DESCRIPTION
### Summary

This PR addresses several localization issues and adds system language auto-detection for first-time users.

### Changes

**Bug Fixes:**

1. **Language switching not working** — The startup code was hardcoding `"en"` in `LoadLanguage()` instead of reading the user's saved language preference from `ApplicationSettings.SelectedLangauge`. This caused the language setting to always reset to English on restart.

2. **Reports > Bmd menu shows raw key** — The XAML uses `MenuBar.Reports.Bmd` but both language JSONs still had the old key `MenuBar.Reports.RmvToText`. When `LocExtension` can't find a translation, it falls back to displaying the raw key string. Fixed by updating the key in both language files.

3. **Kitbash animation panel buttons show raw keys** — `CollapsableFilterControl.xaml.cs` was overriding the XAML `{loc:Loc}` bindings by setting `BrowseButton.Content` to hardcoded English strings `"Browse"` and `"Hide"` in `ToggleSearchFiled()` and `HandleItemDoubleClicked()`. Replaced with DI-based localization lookups that follow the same `IAssetEditorMain` → `LocalizationManager` pattern used by `LocExtension`.

**New Feature:**

4. **Auto-detect system language on first launch** — When `IsFirstTimeStartingApplication` is `true`, reads `CultureInfo.CurrentUICulture.TwoLetterISOLanguageName`, maps `zh`→`cn`, `en`→`en`, `fr`→`fr` (with `en` as fallback), and saves the detected language before the UI loads. A file-existence check ensures the corresponding `Language_*.json` exists before applying.

**Localization Sync:**

5. **Chinese language file (`Language_Cn.json`) brought in sync with English:**
   - Replaced outdated `MenuBar.File.OpenPack` with `MenuBar.File.OpenProjectFolder`
   - Added missing keys: `MenuBar.File.ImportPackAsProject`, `MenuBar.File.ImportReferencePack`
   - Translated all 7 `PackFileCache.*` entries (were English-only)
   - Added `Dialog.Filter.Hide` key

6. **English language file (`Language_En.json`) updated:**
   - `MenuBar.Reports.RmvToText` → `MenuBar.Reports.Bmd`
   - Added `Dialog.Filter.Hide` key

### Files Changed

| File | + | - |
|------|---|---|
| `AssetEditor/App.xaml.cs` | +23 | -1 |
| `AssetEditor/Language_Cn.json` | +13 | -8 |
| `AssetEditor/Language_En.json` | +2 | -1 |
| `Shared/SharedUI/Shared.Ui/BaseDialogs/FilterDialog/CollapsableFilterControl.xaml.cs` | +18 | -4 |

### Testing

- [x] Build passes with 0 errors
- [x] Manual testing: language switching persists across restarts
- [x] Manual testing: first-launch language auto-detection (Chinese Windows → `cn`)
- [x] Manual testing: Reports > Bmd menu displays correct text
- [x] Manual testing: Kitbash animation panel buttons display localized text
